### PR TITLE
fix(core): account for system prompt overhead in context compaction (Fixes #150)

### DIFF
--- a/scripts/core/conversation.js
+++ b/scripts/core/conversation.js
@@ -148,7 +148,17 @@ class ConversationManager {
    * @private
    */
   _getCompactionThreshold(overhead = 0) {
-    const available = Math.max(0, this.maxTokens - Math.max(0, overhead));
+    // Re-read current limit so runtime changes to fallbackContextLimit take effect without reload
+    let contextWindow = this.maxTokens;
+    try {
+      if (typeof game !== 'undefined' && game?.settings?.get) {
+        const current = game.settings.get('simulacrum', 'fallbackContextLimit');
+        if (current && current > 0) contextWindow = current;
+      }
+    } catch {
+      // Ignore — fall back to initialised maxTokens
+    }
+    const available = Math.max(0, contextWindow - Math.max(0, overhead));
     const contextTarget = Math.floor(available * 0.33); // 33% of available space for working memory
     const compactionPromptSize = 500; // Overhead for summarization prompt
     return Math.max(0, available - contextTarget - compactionPromptSize);

--- a/scripts/core/conversation.js
+++ b/scripts/core/conversation.js
@@ -62,8 +62,9 @@ class ConversationManager {
       if (metadata._internal === true) {
         message._internal = true;
       }
-      // Store provider metadata separately
-      const { _internal, ...providerMeta } = metadata;
+      // Store provider metadata separately (strip _internal which is internal-only)
+      const providerMeta = Object.assign({}, metadata);
+      delete providerMeta._internal;
       if (Object.keys(providerMeta).length > 0) {
         message.provider_metadata = providerMeta;
       }
@@ -109,6 +110,15 @@ class ConversationManager {
   }
 
   /**
+   * Estimate tokens for a message. Public wrapper for external callers.
+   * @param {object} message
+   * @returns {number}
+   */
+  estimateTokens(message) {
+    return this._estimateTokens(message);
+  }
+
+  /**
    * Calculate the compaction threshold based on model context window
    * @param {number} [overhead=0] - Additional token overhead to reserve (e.g. system prompt tokens)
    * @returns {number} Token threshold for triggering compaction
@@ -116,7 +126,7 @@ class ConversationManager {
    */
   _getCompactionThreshold(overhead = 0) {
     const contextWindow = this.maxTokens;
-    const available = contextWindow - overhead;
+    const available = Math.max(0, contextWindow - overhead);
     const contextTarget = Math.floor(available * 0.33); // 33% of available space for working memory
     const compactionPromptSize = 500; // Overhead for summarization prompt
     return available - contextTarget - compactionPromptSize;
@@ -152,44 +162,23 @@ class ConversationManager {
   }
 
   /**
-   * Compact history using AI-driven summarization
-   * @param {object} aiClient - AI client for summarization calls
-   * @param {number} [overhead=0] - Token overhead to reserve (e.g. system prompt tokens)
-   * @returns {Promise<boolean>} Whether compaction occurred
+   * Find the end index of the chunk to compact, respecting tool call/response pairing.
+   * @param {number} startIdx - Index of first non-system message
+   * @returns {number} Exclusive end index of the chunk
+   * @private
    */
-  async compactHistory(aiClient, overhead = 0) {
-    const threshold = this._getCompactionThreshold(overhead);
-    const currentTokens = this.sessionTokens;
-
-    if (currentTokens <= threshold) {
-      return false; // No compaction needed
-    }
-
-    // Extract oldest messages to compact (keep system message)
-    // Extract oldest messages to compact (keep system message)
-    const systemMsg = this.activeMessages[0]?.role === 'system' ? this.activeMessages[0] : null;
-    const startIdx = systemMsg ? 1 : 0;
-
-    // Define initial chunk size
+  _findCompactionChunkEnd(startIdx) {
     let chunkEnd = startIdx + 5;
 
-    // Boundary Check 1: prevent stranding a tool message as an orphan
-    // If the message that would become the new head (at chunkEnd) is a 'tool' message,
-    // we must include it in the compaction batch (consume it).
-    // We implicitly assume that if we are compacting the parent Assistant message,
-    // we must also compact its children Tool messages.
+    // Don't strand a tool response as the new head — consume it with its parent
     while (chunkEnd < this.activeMessages.length && this.activeMessages[chunkEnd].role === 'tool') {
       chunkEnd++;
     }
 
-    // Boundary Check 2: If the last message we're keeping (at chunkEnd - 1) is an assistant
-    // message with tool_calls, we need to include all its corresponding tool responses.
-    // Otherwise, we'd leave orphaned tool responses in the remaining messages.
-    while (chunkEnd > startIdx) {
+    // If the last compacted message has tool_calls, include all its tool responses
+    if (chunkEnd > startIdx) {
       const lastCompacted = this.activeMessages[chunkEnd - 1];
       if (lastCompacted?.role === 'assistant' && lastCompacted?.tool_calls?.length > 0) {
-        // This assistant has tool_calls - we must include its tool responses
-        // Count how many tool responses follow
         const toolCallIds = new Set(lastCompacted.tool_calls.map(tc => tc.id));
         while (
           chunkEnd < this.activeMessages.length &&
@@ -198,18 +187,31 @@ class ConversationManager {
         ) {
           chunkEnd++;
         }
-        break; // Only need to check the last message once
       }
-      break;
     }
 
+    return chunkEnd;
+  }
+
+  /**
+   * Compact history using AI-driven summarization
+   * @param {object} aiClient - AI client for summarization calls
+   * @param {number} [overhead=0] - Token overhead to reserve (e.g. system prompt tokens)
+   * @returns {Promise<boolean>} Whether compaction occurred
+   */
+  async compactHistory(aiClient, overhead = 0) {
+    if (this.sessionTokens <= this._getCompactionThreshold(overhead)) {
+      return false;
+    }
+
+    const startIdx = this.activeMessages[0]?.role === 'system' ? 1 : 0;
+    const chunkEnd = this._findCompactionChunkEnd(startIdx);
     const messagesToCompact = this.activeMessages.slice(startIdx, chunkEnd);
 
     if (messagesToCompact.length === 0) {
       return false;
     }
 
-    // Build summarization prompt
     const prompt = this._buildSummarizationPrompt(messagesToCompact);
 
     try {
@@ -220,16 +222,11 @@ class ConversationManager {
       const newSummary = response?.choices?.[0]?.message?.content || '';
       if (newSummary) {
         this.rollingSummary = newSummary;
-
-        // 4. Update state: remove compacted messages, keep system + summary + remaining
         this.activeMessages = [
           ...this.activeMessages.slice(0, startIdx),
           ...this.activeMessages.slice(chunkEnd),
         ];
-
-        // Sync messages array for backward compatibility
         this.messages = [...this.activeMessages];
-
         this._recalculateTokens();
         this._triggerStateChange();
         return true;
@@ -518,17 +515,14 @@ class ConversationManager {
   _sanitizeMessages() {
     if (!this.activeMessages || this.activeMessages.length === 0) return;
 
-    // Build sets of expected tool responses and received tool responses
-    const expectedToolResponses = new Map(); // tool_call_id -> index of assistant message
+    const expectedToolResponses = new Map();
     const receivedToolResponses = new Set();
 
     for (let i = 0; i < this.activeMessages.length; i++) {
       const msg = this.activeMessages[i];
       if (msg.role === 'assistant' && Array.isArray(msg.tool_calls)) {
         for (const tc of msg.tool_calls) {
-          if (tc.id) {
-            expectedToolResponses.set(tc.id, i);
-          }
+          if (tc.id) expectedToolResponses.set(tc.id, i);
         }
       }
       if (msg.role === 'tool' && msg.tool_call_id) {
@@ -536,75 +530,62 @@ class ConversationManager {
       }
     }
 
-    // Find mismatches
     const missingResponses = [...expectedToolResponses.keys()].filter(
       id => !receivedToolResponses.has(id)
     );
     const orphanResponses = [...receivedToolResponses].filter(id => !expectedToolResponses.has(id));
 
-    if (missingResponses.length === 0 && orphanResponses.length === 0) {
-      return; // No issues to fix
-    }
+    if (missingResponses.length === 0 && orphanResponses.length === 0) return;
 
     logger.warn('Sanitizing conversation history:', {
       missingToolResponses: missingResponses.length,
       orphanToolResponses: orphanResponses.length,
     });
 
-    // Strategy 1: Add stub responses for missing tool responses
-    // Find where to insert them (after the assistant message with the tool_calls)
     if (missingResponses.length > 0) {
-      const stubResponse = {
-        error:
-          'Tool execution was interrupted or the conversation was restored from a previous session.',
-        stale: true,
-      };
-
-      // Group missing responses by their assistant message index
-      const insertions = [];
-      for (const toolCallId of missingResponses) {
-        const assistantIdx = expectedToolResponses.get(toolCallId);
-        insertions.push({
-          afterIndex: assistantIdx,
-          message: {
-            role: 'tool',
-            content: JSON.stringify(stubResponse),
-            tool_call_id: toolCallId,
-          },
-        });
-      }
-
-      // Sort by index descending so we can insert without shifting indices
-      insertions.sort((a, b) => b.afterIndex - a.afterIndex);
-
-      for (const ins of insertions) {
-        // Find the correct position: after the assistant message and any existing tool responses
-        let insertPos = ins.afterIndex + 1;
-        while (
-          insertPos < this.activeMessages.length &&
-          this.activeMessages[insertPos].role === 'tool'
-        ) {
-          insertPos++;
-        }
-        this.activeMessages.splice(insertPos, 0, ins.message);
-      }
+      this._stubMissingToolResponses(missingResponses, expectedToolResponses);
     }
-
-    // Strategy 2: Remove orphan tool responses (responses without matching tool_calls)
     if (orphanResponses.length > 0) {
-      this.activeMessages = this.activeMessages.filter(msg => {
-        if (msg.role === 'tool' && msg.tool_call_id) {
-          return !orphanResponses.includes(msg.tool_call_id);
-        }
-        return true;
-      });
+      this._pruneOrphanToolResponses(orphanResponses);
     }
 
-    // Sync messages array
     this.messages = [...this.activeMessages];
     this._recalculateTokens();
-
     if (isDebugEnabled()) logger.debug('Conversation history sanitized successfully');
+  }
+
+  /** @private */
+  _stubMissingToolResponses(missingResponses, expectedToolResponses) {
+    const stubContent = JSON.stringify({
+      error:
+        'Tool execution was interrupted or the conversation was restored from a previous session.',
+      stale: true,
+    });
+
+    const insertions = missingResponses.map(toolCallId => ({
+      afterIndex: expectedToolResponses.get(toolCallId),
+      message: { role: 'tool', content: stubContent, tool_call_id: toolCallId },
+    }));
+
+    insertions.sort((a, b) => b.afterIndex - a.afterIndex);
+
+    for (const ins of insertions) {
+      let insertPos = ins.afterIndex + 1;
+      while (
+        insertPos < this.activeMessages.length &&
+        this.activeMessages[insertPos].role === 'tool'
+      ) {
+        insertPos++;
+      }
+      this.activeMessages.splice(insertPos, 0, ins.message);
+    }
+  }
+
+  /** @private */
+  _pruneOrphanToolResponses(orphanResponses) {
+    this.activeMessages = this.activeMessages.filter(
+      msg => !(msg.role === 'tool' && msg.tool_call_id && orphanResponses.includes(msg.tool_call_id))
+    );
   }
 }
 

--- a/scripts/core/conversation.js
+++ b/scripts/core/conversation.js
@@ -127,14 +127,18 @@ class ConversationManager {
   /**
    * Estimate system prompt overhead that is not already represented in sessionTokens.
    * getSystemPrompt() embeds rollingSummary, while sessionTokens also tracks it.
+   * Uses the same tokenizer for both terms so the subtraction is internally consistent.
    * @param {string} systemPrompt
-   * @param {boolean} [includesRollingSummary=true]
+   * @param {boolean} [includeRollingSummary=true]
    * @returns {number}
    */
-  estimatePromptOverhead(systemPrompt, includesRollingSummary = true) {
+  estimatePromptOverhead(systemPrompt, includeRollingSummary = true) {
     const promptTokens = this.estimateTokens({ role: 'system', content: systemPrompt });
-    const countedSummaryTokens = includesRollingSummary ? this._estimateRollingSummaryTokens() : 0;
-    return Math.max(0, promptTokens - countedSummaryTokens);
+    const summaryTokens =
+      includeRollingSummary && this.rollingSummary
+        ? this.estimateTokens({ role: 'system', content: this.rollingSummary })
+        : 0;
+    return Math.max(0, promptTokens - summaryTokens);
   }
 
   /**
@@ -370,7 +374,7 @@ class ConversationManager {
     if (changed) {
       this.messages = [...this.activeMessages];
       this._triggerStateChange();
-      logger.warn('Conversation history truncated after compaction round limit');
+      logger.warn('Conversation history truncated to fit context window');
     }
 
     return changed;

--- a/scripts/core/conversation.js
+++ b/scripts/core/conversation.js
@@ -11,6 +11,7 @@ import { createLogger, isDebugEnabled } from '../utils/logger.js';
 import { interactionLogger } from './interaction-logger.js';
 
 const logger = createLogger('Conversation');
+const MAX_COMPACTION_ROUNDS = 10;
 
 class ConversationManager {
   /**
@@ -312,8 +313,10 @@ class ConversationManager {
         ...this.activeMessages.slice(chunkEnd),
       ];
       changed = true;
-      this._sanitizeMessages();
-      this._recalculateTokens();
+      const sanitized = this._sanitizeMessages();
+      if (!sanitized) {
+        this._recalculateTokens();
+      }
     }
 
     if (changed) {
@@ -597,10 +600,11 @@ class ConversationManager {
    * - Old conversations with incomplete tool executions
    * - Conversations interrupted during tool execution
    * - Tool changes (additions/removals) between sessions
+   * @returns {boolean} Whether the history was modified
    * @private
    */
   _sanitizeMessages() {
-    if (!this.activeMessages || this.activeMessages.length === 0) return;
+    if (!this.activeMessages || this.activeMessages.length === 0) return false;
 
     const expectedToolResponses = new Map();
     const receivedToolResponses = new Set();
@@ -622,7 +626,7 @@ class ConversationManager {
     );
     const orphanResponses = [...receivedToolResponses].filter(id => !expectedToolResponses.has(id));
 
-    if (missingResponses.length === 0 && orphanResponses.length === 0) return;
+    if (missingResponses.length === 0 && orphanResponses.length === 0) return false;
 
     logger.warn('Sanitizing conversation history:', {
       missingToolResponses: missingResponses.length,
@@ -639,6 +643,7 @@ class ConversationManager {
     this.messages = [...this.activeMessages];
     this._recalculateTokens();
     if (isDebugEnabled()) logger.debug('Conversation history sanitized successfully');
+    return true;
   }
 
   /** @private */
@@ -677,4 +682,4 @@ class ConversationManager {
   }
 }
 
-export { ConversationManager };
+export { ConversationManager, MAX_COMPACTION_ROUNDS };

--- a/scripts/core/conversation.js
+++ b/scripts/core/conversation.js
@@ -110,14 +110,16 @@ class ConversationManager {
 
   /**
    * Calculate the compaction threshold based on model context window
+   * @param {number} [overhead=0] - Additional token overhead to reserve (e.g. system prompt tokens)
    * @returns {number} Token threshold for triggering compaction
    * @private
    */
-  _getCompactionThreshold() {
+  _getCompactionThreshold(overhead = 0) {
     const contextWindow = this.maxTokens;
-    const contextTarget = Math.floor(contextWindow * 0.33); // 33% for working memory
+    const available = contextWindow - overhead;
+    const contextTarget = Math.floor(available * 0.33); // 33% of available space for working memory
     const compactionPromptSize = 500; // Overhead for summarization prompt
-    return contextWindow - contextTarget - compactionPromptSize;
+    return available - contextTarget - compactionPromptSize;
   }
 
   /**
@@ -152,10 +154,11 @@ class ConversationManager {
   /**
    * Compact history using AI-driven summarization
    * @param {object} aiClient - AI client for summarization calls
+   * @param {number} [overhead=0] - Token overhead to reserve (e.g. system prompt tokens)
    * @returns {Promise<boolean>} Whether compaction occurred
    */
-  async compactHistory(aiClient) {
-    const threshold = this._getCompactionThreshold();
+  async compactHistory(aiClient, overhead = 0) {
+    const threshold = this._getCompactionThreshold(overhead);
     const currentTokens = this.sessionTokens;
 
     if (currentTokens <= threshold) {

--- a/scripts/core/conversation.js
+++ b/scripts/core/conversation.js
@@ -142,55 +142,16 @@ class ConversationManager {
   }
 
   /**
-   * Check whether the current conversation is within the compaction budget.
-   * @param {number} [overhead=0]
-   * @param {boolean} [includeRollingSummary=true]
-   * @returns {boolean}
-   */
-  isWithinCompactionBudget(overhead = 0, includeRollingSummary = true) {
-    return this._getBudgetTokens(includeRollingSummary) <= this._getCompactionThreshold(overhead);
-  }
-
-  /**
-   * Check whether non-conversation prompt overhead leaves any context for messages.
-   * @param {number} [overhead=0]
-   * @returns {boolean}
-   */
-  hasAvailableContext(overhead = 0) {
-    return Math.max(0, overhead) < this.maxTokens;
-  }
-
-  /**
-   * Check whether the current request fits within the model context window.
-   * @param {number} [overhead=0]
-   * @param {boolean} [includeRollingSummary=true]
-   * @returns {boolean}
-   */
-  isWithinContextWindow(overhead = 0, includeRollingSummary = true) {
-    return this._getBudgetTokens(includeRollingSummary) <= this._getContextWindowBudget(overhead);
-  }
-
-  /**
    * Calculate the compaction threshold based on model context window
    * @param {number} [overhead=0] - Additional token overhead to reserve (e.g. system prompt tokens)
    * @returns {number} Token threshold for triggering compaction
    * @private
    */
   _getCompactionThreshold(overhead = 0) {
-    const available = this._getContextWindowBudget(overhead);
+    const available = Math.max(0, this.maxTokens - Math.max(0, overhead));
     const contextTarget = Math.floor(available * 0.33); // 33% of available space for working memory
     const compactionPromptSize = 500; // Overhead for summarization prompt
     return Math.max(0, available - contextTarget - compactionPromptSize);
-  }
-
-  /**
-   * Calculate the absolute conversation budget left after prompt overhead.
-   * @param {number} [overhead=0]
-   * @returns {number}
-   * @private
-   */
-  _getContextWindowBudget(overhead = 0) {
-    return Math.max(0, this.maxTokens - Math.max(0, overhead));
   }
 
   /**
@@ -231,17 +192,6 @@ class ConversationManager {
   }
 
   /**
-   * Get conversation tokens relevant to the request budget.
-   * @param {boolean} includeRollingSummary
-   * @returns {number}
-   * @private
-   */
-  _getBudgetTokens(includeRollingSummary) {
-    if (includeRollingSummary) return this.sessionTokens;
-    return Math.max(0, this.sessionTokens - this._estimateRollingSummaryTokens());
-  }
-
-  /**
    * Find the end index of the chunk to compact, respecting tool call/response pairing.
    * @param {number} startIdx - Index of first non-system message
    * @returns {number} Exclusive end index of the chunk
@@ -277,11 +227,10 @@ class ConversationManager {
    * Compact history using AI-driven summarization
    * @param {object} aiClient - AI client for summarization calls
    * @param {number} [overhead=0] - Token overhead to reserve (e.g. system prompt tokens)
-   * @param {boolean} [includeRollingSummary=true] - Whether request prompt includes rolling summary
    * @returns {Promise<string>} Compaction status
    */
-  async compactHistory(aiClient, overhead = 0, includeRollingSummary = true) {
-    if (this.isWithinCompactionBudget(overhead, includeRollingSummary)) {
+  async compactHistory(aiClient, overhead = 0) {
+    if (this.sessionTokens <= this._getCompactionThreshold(overhead)) {
       return COMPACTION_STATUS.WITHIN_BUDGET;
     }
 
@@ -317,67 +266,6 @@ class ConversationManager {
     }
 
     return COMPACTION_STATUS.FAILED;
-  }
-
-  /**
-   * Deterministically drop oldest active messages until the request is within budget.
-   * Used only after AI compaction hits its safety cap.
-   * @param {number} [overhead=0]
-   * @param {boolean} [includeRollingSummary=true]
-   * @returns {boolean} Whether any messages were removed
-   */
-  truncateToCompactionBudget(overhead = 0, includeRollingSummary = true) {
-    return this._truncateUntilWithin(() =>
-      this.isWithinCompactionBudget(overhead, includeRollingSummary)
-    );
-  }
-
-  /**
-   * Deterministically drop oldest active messages until the request fits the context window.
-   * @param {number} [overhead=0]
-   * @param {boolean} [includeRollingSummary=true]
-   * @returns {boolean} Whether any messages were removed
-   */
-  truncateToContextWindow(overhead = 0, includeRollingSummary = true) {
-    return this._truncateUntilWithin(() =>
-      this.isWithinContextWindow(overhead, includeRollingSummary)
-    );
-  }
-
-  /**
-   * Deterministically drop oldest active messages until a supplied budget predicate is satisfied.
-   * @param {Function} isWithinBudget
-   * @returns {boolean} Whether any messages were removed
-   * @private
-   */
-  _truncateUntilWithin(isWithinBudget) {
-    let changed = false;
-
-    while (!isWithinBudget()) {
-      const startIdx = this.activeMessages[0]?.role === 'system' ? 1 : 0;
-      if (this.activeMessages.length <= startIdx) break;
-
-      const chunkEnd = this._findCompactionChunkEnd(startIdx);
-      if (chunkEnd <= startIdx) break;
-
-      this.activeMessages = [
-        ...this.activeMessages.slice(0, startIdx),
-        ...this.activeMessages.slice(chunkEnd),
-      ];
-      changed = true;
-      const sanitized = this._sanitizeMessages();
-      if (!sanitized) {
-        this._recalculateTokens();
-      }
-    }
-
-    if (changed) {
-      this.messages = [...this.activeMessages];
-      this._triggerStateChange();
-      logger.warn('Conversation history truncated to fit context window');
-    }
-
-    return changed;
   }
 
   /**

--- a/scripts/core/conversation.js
+++ b/scripts/core/conversation.js
@@ -122,20 +122,23 @@ class ConversationManager {
    * Estimate system prompt overhead that is not already represented in sessionTokens.
    * getSystemPrompt() embeds rollingSummary, while sessionTokens also tracks it.
    * @param {string} systemPrompt
+   * @param {boolean} [includesRollingSummary=true]
    * @returns {number}
    */
-  estimatePromptOverhead(systemPrompt) {
+  estimatePromptOverhead(systemPrompt, includesRollingSummary = true) {
     const promptTokens = this.estimateTokens({ role: 'system', content: systemPrompt });
-    return Math.max(0, promptTokens - this._estimateRollingSummaryTokens());
+    const countedSummaryTokens = includesRollingSummary ? this._estimateRollingSummaryTokens() : 0;
+    return Math.max(0, promptTokens - countedSummaryTokens);
   }
 
   /**
    * Check whether the current conversation is within the compaction budget.
    * @param {number} [overhead=0]
+   * @param {boolean} [includeRollingSummary=true]
    * @returns {boolean}
    */
-  isWithinCompactionBudget(overhead = 0) {
-    return this.sessionTokens <= this._getCompactionThreshold(overhead);
+  isWithinCompactionBudget(overhead = 0, includeRollingSummary = true) {
+    return this._getBudgetTokens(includeRollingSummary) <= this._getCompactionThreshold(overhead);
   }
 
   /**
@@ -199,6 +202,17 @@ class ConversationManager {
   }
 
   /**
+   * Get conversation tokens relevant to the request budget.
+   * @param {boolean} includeRollingSummary
+   * @returns {number}
+   * @private
+   */
+  _getBudgetTokens(includeRollingSummary) {
+    if (includeRollingSummary) return this.sessionTokens;
+    return Math.max(0, this.sessionTokens - this._estimateRollingSummaryTokens());
+  }
+
+  /**
    * Find the end index of the chunk to compact, respecting tool call/response pairing.
    * @param {number} startIdx - Index of first non-system message
    * @returns {number} Exclusive end index of the chunk
@@ -234,10 +248,11 @@ class ConversationManager {
    * Compact history using AI-driven summarization
    * @param {object} aiClient - AI client for summarization calls
    * @param {number} [overhead=0] - Token overhead to reserve (e.g. system prompt tokens)
+   * @param {boolean} [includeRollingSummary=true] - Whether request prompt includes rolling summary
    * @returns {Promise<boolean>} Whether compaction occurred
    */
-  async compactHistory(aiClient, overhead = 0) {
-    if (this.isWithinCompactionBudget(overhead)) {
+  async compactHistory(aiClient, overhead = 0, includeRollingSummary = true) {
+    if (this.isWithinCompactionBudget(overhead, includeRollingSummary)) {
       return false;
     }
 
@@ -279,12 +294,13 @@ class ConversationManager {
    * Deterministically drop oldest active messages until the request is within budget.
    * Used only after AI compaction hits its safety cap.
    * @param {number} [overhead=0]
+   * @param {boolean} [includeRollingSummary=true]
    * @returns {boolean} Whether any messages were removed
    */
-  truncateToCompactionBudget(overhead = 0) {
+  truncateToCompactionBudget(overhead = 0, includeRollingSummary = true) {
     let changed = false;
 
-    while (!this.isWithinCompactionBudget(overhead)) {
+    while (!this.isWithinCompactionBudget(overhead, includeRollingSummary)) {
       const startIdx = this.activeMessages[0]?.role === 'system' ? 1 : 0;
       if (this.activeMessages.length <= startIdx) break;
 
@@ -302,7 +318,6 @@ class ConversationManager {
 
     if (changed) {
       this.messages = [...this.activeMessages];
-      this._recalculateTokens();
       this._triggerStateChange();
       logger.warn('Conversation history truncated after compaction round limit');
     }
@@ -656,7 +671,8 @@ class ConversationManager {
   /** @private */
   _pruneOrphanToolResponses(orphanResponses) {
     this.activeMessages = this.activeMessages.filter(
-      msg => !(msg.role === 'tool' && msg.tool_call_id && orphanResponses.includes(msg.tool_call_id))
+      msg =>
+        !(msg.role === 'tool' && msg.tool_call_id && orphanResponses.includes(msg.tool_call_id))
     );
   }
 }

--- a/scripts/core/conversation.js
+++ b/scripts/core/conversation.js
@@ -12,6 +12,11 @@ import { interactionLogger } from './interaction-logger.js';
 
 const logger = createLogger('Conversation');
 const MAX_COMPACTION_ROUNDS = 10;
+const COMPACTION_STATUS = Object.freeze({
+  WITHIN_BUDGET: 'within_budget',
+  COMPACTED: 'compacted',
+  FAILED: 'failed',
+});
 
 class ConversationManager {
   /**
@@ -152,17 +157,36 @@ class ConversationManager {
   }
 
   /**
+   * Check whether the current request fits within the model context window.
+   * @param {number} [overhead=0]
+   * @param {boolean} [includeRollingSummary=true]
+   * @returns {boolean}
+   */
+  isWithinContextWindow(overhead = 0, includeRollingSummary = true) {
+    return this._getBudgetTokens(includeRollingSummary) <= this._getContextWindowBudget(overhead);
+  }
+
+  /**
    * Calculate the compaction threshold based on model context window
    * @param {number} [overhead=0] - Additional token overhead to reserve (e.g. system prompt tokens)
    * @returns {number} Token threshold for triggering compaction
    * @private
    */
   _getCompactionThreshold(overhead = 0) {
-    const contextWindow = this.maxTokens;
-    const available = Math.max(0, contextWindow - Math.max(0, overhead));
+    const available = this._getContextWindowBudget(overhead);
     const contextTarget = Math.floor(available * 0.33); // 33% of available space for working memory
     const compactionPromptSize = 500; // Overhead for summarization prompt
     return Math.max(0, available - contextTarget - compactionPromptSize);
+  }
+
+  /**
+   * Calculate the absolute conversation budget left after prompt overhead.
+   * @param {number} [overhead=0]
+   * @returns {number}
+   * @private
+   */
+  _getContextWindowBudget(overhead = 0) {
+    return Math.max(0, this.maxTokens - Math.max(0, overhead));
   }
 
   /**
@@ -250,11 +274,11 @@ class ConversationManager {
    * @param {object} aiClient - AI client for summarization calls
    * @param {number} [overhead=0] - Token overhead to reserve (e.g. system prompt tokens)
    * @param {boolean} [includeRollingSummary=true] - Whether request prompt includes rolling summary
-   * @returns {Promise<boolean>} Whether compaction occurred
+   * @returns {Promise<string>} Compaction status
    */
   async compactHistory(aiClient, overhead = 0, includeRollingSummary = true) {
     if (this.isWithinCompactionBudget(overhead, includeRollingSummary)) {
-      return false;
+      return COMPACTION_STATUS.WITHIN_BUDGET;
     }
 
     const startIdx = this.activeMessages[0]?.role === 'system' ? 1 : 0;
@@ -262,7 +286,7 @@ class ConversationManager {
     const messagesToCompact = this.activeMessages.slice(startIdx, chunkEnd);
 
     if (messagesToCompact.length === 0) {
-      return false;
+      return COMPACTION_STATUS.FAILED;
     }
 
     const prompt = this._buildSummarizationPrompt(messagesToCompact);
@@ -282,13 +306,13 @@ class ConversationManager {
         this.messages = [...this.activeMessages];
         this._recalculateTokens();
         this._triggerStateChange();
-        return true;
+        return COMPACTION_STATUS.COMPACTED;
       }
     } catch (error) {
       logger.warn('Compaction failed:', error);
     }
 
-    return false;
+    return COMPACTION_STATUS.FAILED;
   }
 
   /**
@@ -299,9 +323,33 @@ class ConversationManager {
    * @returns {boolean} Whether any messages were removed
    */
   truncateToCompactionBudget(overhead = 0, includeRollingSummary = true) {
+    return this._truncateUntilWithin(() =>
+      this.isWithinCompactionBudget(overhead, includeRollingSummary)
+    );
+  }
+
+  /**
+   * Deterministically drop oldest active messages until the request fits the context window.
+   * @param {number} [overhead=0]
+   * @param {boolean} [includeRollingSummary=true]
+   * @returns {boolean} Whether any messages were removed
+   */
+  truncateToContextWindow(overhead = 0, includeRollingSummary = true) {
+    return this._truncateUntilWithin(() =>
+      this.isWithinContextWindow(overhead, includeRollingSummary)
+    );
+  }
+
+  /**
+   * Deterministically drop oldest active messages until a supplied budget predicate is satisfied.
+   * @param {Function} isWithinBudget
+   * @returns {boolean} Whether any messages were removed
+   * @private
+   */
+  _truncateUntilWithin(isWithinBudget) {
     let changed = false;
 
-    while (!this.isWithinCompactionBudget(overhead, includeRollingSummary)) {
+    while (!isWithinBudget()) {
       const startIdx = this.activeMessages[0]?.role === 'system' ? 1 : 0;
       if (this.activeMessages.length <= startIdx) break;
 
@@ -682,4 +730,4 @@ class ConversationManager {
   }
 }
 
-export { ConversationManager, MAX_COMPACTION_ROUNDS };
+export { ConversationManager, MAX_COMPACTION_ROUNDS, COMPACTION_STATUS };

--- a/scripts/core/conversation.js
+++ b/scripts/core/conversation.js
@@ -119,6 +119,35 @@ class ConversationManager {
   }
 
   /**
+   * Estimate system prompt overhead that is not already represented in sessionTokens.
+   * getSystemPrompt() embeds rollingSummary, while sessionTokens also tracks it.
+   * @param {string} systemPrompt
+   * @returns {number}
+   */
+  estimatePromptOverhead(systemPrompt) {
+    const promptTokens = this.estimateTokens({ role: 'system', content: systemPrompt });
+    return Math.max(0, promptTokens - this._estimateRollingSummaryTokens());
+  }
+
+  /**
+   * Check whether the current conversation is within the compaction budget.
+   * @param {number} [overhead=0]
+   * @returns {boolean}
+   */
+  isWithinCompactionBudget(overhead = 0) {
+    return this.sessionTokens <= this._getCompactionThreshold(overhead);
+  }
+
+  /**
+   * Check whether non-conversation prompt overhead leaves any context for messages.
+   * @param {number} [overhead=0]
+   * @returns {boolean}
+   */
+  hasAvailableContext(overhead = 0) {
+    return Math.max(0, overhead) < this.maxTokens;
+  }
+
+  /**
    * Calculate the compaction threshold based on model context window
    * @param {number} [overhead=0] - Additional token overhead to reserve (e.g. system prompt tokens)
    * @returns {number} Token threshold for triggering compaction
@@ -126,10 +155,10 @@ class ConversationManager {
    */
   _getCompactionThreshold(overhead = 0) {
     const contextWindow = this.maxTokens;
-    const available = Math.max(0, contextWindow - overhead);
+    const available = Math.max(0, contextWindow - Math.max(0, overhead));
     const contextTarget = Math.floor(available * 0.33); // 33% of available space for working memory
     const compactionPromptSize = 500; // Overhead for summarization prompt
-    return available - contextTarget - compactionPromptSize;
+    return Math.max(0, available - contextTarget - compactionPromptSize);
   }
 
   /**
@@ -157,8 +186,16 @@ class ConversationManager {
       (acc, msg) => acc + this._estimateTokens(msg),
       0
     );
-    const summaryTokens = this.rollingSummary ? Math.ceil(this.rollingSummary.length / 4) : 0;
-    this.sessionTokens = messageTokens + summaryTokens;
+    this.sessionTokens = messageTokens + this._estimateRollingSummaryTokens();
+  }
+
+  /**
+   * Estimate rolling summary tokens using the same accounting as sessionTokens.
+   * @returns {number}
+   * @private
+   */
+  _estimateRollingSummaryTokens() {
+    return this.rollingSummary ? Math.ceil(this.rollingSummary.length / 4) : 0;
   }
 
   /**
@@ -200,7 +237,7 @@ class ConversationManager {
    * @returns {Promise<boolean>} Whether compaction occurred
    */
   async compactHistory(aiClient, overhead = 0) {
-    if (this.sessionTokens <= this._getCompactionThreshold(overhead)) {
+    if (this.isWithinCompactionBudget(overhead)) {
       return false;
     }
 
@@ -236,6 +273,41 @@ class ConversationManager {
     }
 
     return false;
+  }
+
+  /**
+   * Deterministically drop oldest active messages until the request is within budget.
+   * Used only after AI compaction hits its safety cap.
+   * @param {number} [overhead=0]
+   * @returns {boolean} Whether any messages were removed
+   */
+  truncateToCompactionBudget(overhead = 0) {
+    let changed = false;
+
+    while (!this.isWithinCompactionBudget(overhead)) {
+      const startIdx = this.activeMessages[0]?.role === 'system' ? 1 : 0;
+      if (this.activeMessages.length <= startIdx) break;
+
+      const chunkEnd = this._findCompactionChunkEnd(startIdx);
+      if (chunkEnd <= startIdx) break;
+
+      this.activeMessages = [
+        ...this.activeMessages.slice(0, startIdx),
+        ...this.activeMessages.slice(chunkEnd),
+      ];
+      changed = true;
+      this._sanitizeMessages();
+      this._recalculateTokens();
+    }
+
+    if (changed) {
+      this.messages = [...this.activeMessages];
+      this._recalculateTokens();
+      this._triggerStateChange();
+      logger.warn('Conversation history truncated after compaction round limit');
+    }
+
+    return changed;
   }
 
   /**

--- a/scripts/core/simulacrum-core.js
+++ b/scripts/core/simulacrum-core.js
@@ -454,6 +454,7 @@ class SimulacrumCore {
     try {
       let rounds = 0;
       let anyCompacted = false;
+      const includeRollingSummary = !useCustomPrompt;
       let promptOverhead = this._estimatePromptOverhead(systemPrompt, useCustomPrompt);
 
       while (rounds < MAX_COMPACTION_ROUNDS) {
@@ -461,10 +462,16 @@ class SimulacrumCore {
         const compacted = await this.conversationManager.compactHistory(
           this.aiClient,
           promptOverhead,
-          !useCustomPrompt
+          includeRollingSummary
         );
         rounds++;
-        if (!compacted) break;
+        if (
+          !compacted &&
+          this.conversationManager.isWithinCompactionBudget(promptOverhead, includeRollingSummary)
+        ) {
+          break;
+        }
+        if (!compacted) continue;
 
         anyCompacted = true;
         systemPrompt = useCustomPrompt ? systemPrompt : await this.getSystemPrompt();
@@ -472,7 +479,7 @@ class SimulacrumCore {
       }
 
       if (anyCompacted) this._notifyCompactionOccurred(options);
-      this._ensureConversationFitsAfterCompaction(promptOverhead, !useCustomPrompt);
+      this._ensureConversationFitsAfterCompaction(promptOverhead, includeRollingSummary);
       return systemPrompt;
     } catch (compactionError) {
       this.logger.warn('Compaction failed:', compactionError);

--- a/scripts/core/simulacrum-core.js
+++ b/scripts/core/simulacrum-core.js
@@ -501,12 +501,17 @@ class SimulacrumCore {
       return;
     }
 
-    this.logger.warn('Compaction round limit reached; truncating oldest conversation history');
-    this.conversationManager.truncateToCompactionBudget(promptOverhead, includeRollingSummary);
+    this.logger.warn('Compaction round limit reached; checking hard context window');
+    if (this.conversationManager.isWithinContextWindow(promptOverhead, includeRollingSummary)) {
+      return;
+    }
 
-    if (!this.conversationManager.isWithinCompactionBudget(promptOverhead, includeRollingSummary)) {
+    this.logger.warn('Conversation exceeds context window; truncating oldest conversation history');
+    this.conversationManager.truncateToContextWindow(promptOverhead, includeRollingSummary);
+
+    if (!this.conversationManager.isWithinContextWindow(promptOverhead, includeRollingSummary)) {
       throw new ValidationError(
-        'Conversation still exceeds context budget after compaction and truncation',
+        'Conversation still exceeds context window after compaction and truncation',
         'contextBudget',
         { promptOverhead, maxTokens: this.conversationManager.maxTokens }
       );

--- a/scripts/core/simulacrum-core.js
+++ b/scripts/core/simulacrum-core.js
@@ -540,7 +540,10 @@ class SimulacrumCore {
     if (isDebugEnabled()) {
       this.logger.debug('Conversation history compacted via rollingSummary');
     }
-    if (options.onAssistantMessage) {
+
+    if (!options?.onAssistantMessage) return;
+
+    try {
       const displayHtml = formatToolCallDisplay(
         {
           toolName: 'optimize_memory',
@@ -556,6 +559,8 @@ class SimulacrumCore {
         content: 'System Event: Conversation history compacted to rolling summary.',
         display: displayHtml,
       });
+    } catch (notificationError) {
+      this.logger.warn('Compaction notification failed:', notificationError);
     }
   }
 }

--- a/scripts/core/simulacrum-core.js
+++ b/scripts/core/simulacrum-core.js
@@ -438,7 +438,7 @@ class SimulacrumCore {
   static async getSystemPrompt() {
     let prompt = await buildSystemPrompt();
     if (this.conversationManager?.rollingSummary) {
-      prompt = `### PREVIOUS CONVERSATION SUMMARY\n${this.conversationManager.rollingSummary}\n\n${prompt}`;
+      prompt = `### PREVIOUS CONVERSATION SUMMARY\n${this.conversationManager.rollingSummary}\n### END OF SUMMARY\n\n${prompt}`;
     }
     return prompt;
   }

--- a/scripts/core/simulacrum-core.js
+++ b/scripts/core/simulacrum-core.js
@@ -234,33 +234,7 @@ class SimulacrumCore {
 
       // Trigger compaction if approaching token limit, looping until within budget
       if (this.conversationManager && this.aiClient) {
-        try {
-          let sysTokens = this.conversationManager.estimateTokens({
-            role: 'system',
-            content: systemPrompt,
-          });
-          let compacted = await this.conversationManager.compactHistory(this.aiClient, sysTokens);
-          let rounds = 0;
-          let anyCompacted = compacted;
-
-          while (compacted && rounds < MAX_COMPACTION_ROUNDS) {
-            rounds++;
-            systemPrompt = useCustomPrompt ? systemPrompt : await this.getSystemPrompt();
-            sysTokens = this.conversationManager.estimateTokens({
-              role: 'system',
-              content: systemPrompt,
-            });
-            compacted = await this.conversationManager.compactHistory(this.aiClient, sysTokens);
-            anyCompacted = anyCompacted || compacted;
-          }
-
-          if (anyCompacted) {
-            this._notifyCompactionOccurred(options);
-          }
-        } catch (compactionError) {
-          // Non-fatal: log and continue with uncompacted history
-          this.logger.warn('Compaction failed, continuing with full history:', compactionError);
-        }
+        systemPrompt = await this._compactHistoryIfNeeded(systemPrompt, useCustomPrompt, options);
       }
 
       // Legacy capping removed in favor of Tiered Context Compaction
@@ -469,6 +443,60 @@ class SimulacrumCore {
       prompt = `### PREVIOUS CONVERSATION SUMMARY\n${this.conversationManager.rollingSummary}\n\n${prompt}`;
     }
     return prompt;
+  }
+
+  static _estimatePromptOverhead(systemPrompt, useCustomPrompt) {
+    if (useCustomPrompt) {
+      return this.conversationManager.estimateTokens({ role: 'system', content: systemPrompt });
+    }
+    return this.conversationManager.estimatePromptOverhead(systemPrompt);
+  }
+
+  static async _compactHistoryIfNeeded(systemPrompt, useCustomPrompt, options) {
+    try {
+      let rounds = 0;
+      let anyCompacted = false;
+      let promptOverhead = this._estimatePromptOverhead(systemPrompt, useCustomPrompt);
+
+      while (rounds < MAX_COMPACTION_ROUNDS) {
+        this._assertPromptFitsContext(promptOverhead);
+        const compacted = await this.conversationManager.compactHistory(
+          this.aiClient,
+          promptOverhead
+        );
+        rounds++;
+        if (!compacted) break;
+
+        anyCompacted = true;
+        systemPrompt = useCustomPrompt ? systemPrompt : await this.getSystemPrompt();
+        promptOverhead = this._estimatePromptOverhead(systemPrompt, useCustomPrompt);
+      }
+
+      if (anyCompacted) this._notifyCompactionOccurred(options);
+      this._ensureConversationFitsAfterCompaction(promptOverhead);
+      return systemPrompt;
+    } catch (compactionError) {
+      this.logger.warn('Compaction failed:', compactionError);
+      throw compactionError;
+    }
+  }
+
+  static _assertPromptFitsContext(promptOverhead) {
+    if (!this.conversationManager.hasAvailableContext(promptOverhead)) {
+      throw new Error('System prompt exceeds the configured context window before conversation history');
+    }
+  }
+
+  static _ensureConversationFitsAfterCompaction(promptOverhead) {
+    this._assertPromptFitsContext(promptOverhead);
+    if (this.conversationManager.isWithinCompactionBudget(promptOverhead)) return;
+
+    this.logger.warn('Compaction round limit reached; truncating oldest conversation history');
+    this.conversationManager.truncateToCompactionBudget(promptOverhead);
+
+    if (!this.conversationManager.isWithinCompactionBudget(promptOverhead)) {
+      throw new Error('Conversation still exceeds context budget after compaction and truncation');
+    }
   }
 
   static _notifyCompactionOccurred(options) {

--- a/scripts/core/simulacrum-core.js
+++ b/scripts/core/simulacrum-core.js
@@ -16,6 +16,7 @@ import {
   sanitizeMessagesForFallback,
 } from '../utils/ai-normalization.js';
 import { smartSliceMessages, formatToolCallDisplay } from '../utils/message-utils.js';
+import { ValidationError } from '../utils/errors.js';
 import { processToolCallLoop } from './tool-loop-handler.js';
 import { emitProcessCancelled } from './hook-manager.js';
 import {
@@ -446,10 +447,7 @@ class SimulacrumCore {
   }
 
   static _estimatePromptOverhead(systemPrompt, useCustomPrompt) {
-    if (useCustomPrompt) {
-      return this.conversationManager.estimateTokens({ role: 'system', content: systemPrompt });
-    }
-    return this.conversationManager.estimatePromptOverhead(systemPrompt);
+    return this.conversationManager.estimatePromptOverhead(systemPrompt, !useCustomPrompt);
   }
 
   static async _compactHistoryIfNeeded(systemPrompt, useCustomPrompt, options) {
@@ -462,7 +460,8 @@ class SimulacrumCore {
         this._assertPromptFitsContext(promptOverhead);
         const compacted = await this.conversationManager.compactHistory(
           this.aiClient,
-          promptOverhead
+          promptOverhead,
+          !useCustomPrompt
         );
         rounds++;
         if (!compacted) break;
@@ -473,7 +472,7 @@ class SimulacrumCore {
       }
 
       if (anyCompacted) this._notifyCompactionOccurred(options);
-      this._ensureConversationFitsAfterCompaction(promptOverhead);
+      this._ensureConversationFitsAfterCompaction(promptOverhead, !useCustomPrompt);
       return systemPrompt;
     } catch (compactionError) {
       this.logger.warn('Compaction failed:', compactionError);
@@ -483,19 +482,29 @@ class SimulacrumCore {
 
   static _assertPromptFitsContext(promptOverhead) {
     if (!this.conversationManager.hasAvailableContext(promptOverhead)) {
-      throw new Error('System prompt exceeds the configured context window before conversation history');
+      throw new ValidationError(
+        'System prompt exceeds the configured context window before conversation history',
+        'contextBudget',
+        { promptOverhead, maxTokens: this.conversationManager.maxTokens }
+      );
     }
   }
 
-  static _ensureConversationFitsAfterCompaction(promptOverhead) {
+  static _ensureConversationFitsAfterCompaction(promptOverhead, includeRollingSummary = true) {
     this._assertPromptFitsContext(promptOverhead);
-    if (this.conversationManager.isWithinCompactionBudget(promptOverhead)) return;
+    if (this.conversationManager.isWithinCompactionBudget(promptOverhead, includeRollingSummary)) {
+      return;
+    }
 
     this.logger.warn('Compaction round limit reached; truncating oldest conversation history');
-    this.conversationManager.truncateToCompactionBudget(promptOverhead);
+    this.conversationManager.truncateToCompactionBudget(promptOverhead, includeRollingSummary);
 
-    if (!this.conversationManager.isWithinCompactionBudget(promptOverhead)) {
-      throw new Error('Conversation still exceeds context budget after compaction and truncation');
+    if (!this.conversationManager.isWithinCompactionBudget(promptOverhead, includeRollingSummary)) {
+      throw new ValidationError(
+        'Conversation still exceeds context budget after compaction and truncation',
+        'contextBudget',
+        { promptOverhead, maxTokens: this.conversationManager.maxTokens }
+      );
     }
   }
 

--- a/scripts/core/simulacrum-core.js
+++ b/scripts/core/simulacrum-core.js
@@ -24,6 +24,8 @@ import {
   getAvailableMacrosList as getMacros,
 } from './system-prompt-builder.js';
 
+const MAX_COMPACTION_ROUNDS = 10;
+
 class SimulacrumCore {
   static logger = createLogger('Core');
   static currentAbortController = null; // Track current cancellation controller
@@ -226,47 +228,34 @@ class SimulacrumCore {
       // const contextLength = game?.settings?.get('simulacrum', 'contextLength') || 20;
 
       // Get system prompt early so compaction can account for its token overhead
-      const systemPrompt = options.systemPrompt || (await this.getSystemPrompt());
+      const useCustomPrompt = !!options.systemPrompt;
+      let systemPrompt = options.systemPrompt || (await this.getSystemPrompt());
       const getSystemPromptFn = () => systemPrompt;
 
-      // Trigger compaction if approaching token limit (Context Compaction feature)
+      // Trigger compaction if approaching token limit, looping until within budget
       if (this.conversationManager && this.aiClient) {
         try {
-          const systemPromptTokens = this.conversationManager._estimateTokens({
+          let sysTokens = this.conversationManager.estimateTokens({
             role: 'system',
             content: systemPrompt,
           });
-          let compacted = true;
-          let anyCompacted = false;
-          while (compacted) {
-            compacted = await this.conversationManager.compactHistory(
-              this.aiClient,
-              systemPromptTokens
-            );
+          let compacted = await this.conversationManager.compactHistory(this.aiClient, sysTokens);
+          let rounds = 0;
+          let anyCompacted = compacted;
+
+          while (compacted && rounds < MAX_COMPACTION_ROUNDS) {
+            rounds++;
+            systemPrompt = useCustomPrompt ? systemPrompt : await this.getSystemPrompt();
+            sysTokens = this.conversationManager.estimateTokens({
+              role: 'system',
+              content: systemPrompt,
+            });
+            compacted = await this.conversationManager.compactHistory(this.aiClient, sysTokens);
             anyCompacted = anyCompacted || compacted;
           }
+
           if (anyCompacted) {
-            if (isDebugEnabled()) {
-              this.logger.debug('Conversation history compacted via rollingSummary');
-            }
-            // UX: Show compaction as a simulated tool call
-            if (options.onAssistantMessage) {
-              const displayHtml = formatToolCallDisplay(
-                {
-                  toolName: 'optimize_memory',
-                  content: JSON.stringify({
-                    display: 'Compacted conversation history into working memory summary.',
-                  }),
-                  isError: false,
-                },
-                'optimize_memory'
-              );
-              options.onAssistantMessage({
-                role: 'assistant',
-                content: 'System Event: Conversation history compacted to rolling summary.', // Persist to history
-                display: displayHtml,
-              });
-            }
+            this._notifyCompactionOccurred(options);
           }
         } catch (compactionError) {
           // Non-fatal: log and continue with uncompacted history
@@ -480,6 +469,29 @@ class SimulacrumCore {
       prompt = `### PREVIOUS CONVERSATION SUMMARY\n${this.conversationManager.rollingSummary}\n\n${prompt}`;
     }
     return prompt;
+  }
+
+  static _notifyCompactionOccurred(options) {
+    if (isDebugEnabled()) {
+      this.logger.debug('Conversation history compacted via rollingSummary');
+    }
+    if (options.onAssistantMessage) {
+      const displayHtml = formatToolCallDisplay(
+        {
+          toolName: 'optimize_memory',
+          content: JSON.stringify({
+            display: 'Compacted conversation history into working memory summary.',
+          }),
+          isError: false,
+        },
+        'optimize_memory'
+      );
+      options.onAssistantMessage({
+        role: 'assistant',
+        content: 'System Event: Conversation history compacted to rolling summary.',
+        display: displayHtml,
+      });
+    }
   }
 }
 // Export the SimulacrumCore class

--- a/scripts/core/simulacrum-core.js
+++ b/scripts/core/simulacrum-core.js
@@ -225,11 +225,27 @@ class SimulacrumCore {
       // Get context length setting and limit conversation history
       // const contextLength = game?.settings?.get('simulacrum', 'contextLength') || 20;
 
+      // Get system prompt early so compaction can account for its token overhead
+      const systemPrompt = options.systemPrompt || (await this.getSystemPrompt());
+      const getSystemPromptFn = () => systemPrompt;
+
       // Trigger compaction if approaching token limit (Context Compaction feature)
       if (this.conversationManager && this.aiClient) {
         try {
-          const compacted = await this.conversationManager.compactHistory(this.aiClient);
-          if (compacted) {
+          const systemPromptTokens = this.conversationManager._estimateTokens({
+            role: 'system',
+            content: systemPrompt,
+          });
+          let compacted = true;
+          let anyCompacted = false;
+          while (compacted) {
+            compacted = await this.conversationManager.compactHistory(
+              this.aiClient,
+              systemPromptTokens
+            );
+            anyCompacted = anyCompacted || compacted;
+          }
+          if (anyCompacted) {
             if (isDebugEnabled()) {
               this.logger.debug('Conversation history compacted via rollingSummary');
             }
@@ -290,10 +306,6 @@ class SimulacrumCore {
       if (signal.aborted) {
         throw new Error('Process was cancelled');
       }
-
-      // Get system prompt (use provided or default)
-      const systemPrompt = options.systemPrompt || (await this.getSystemPrompt());
-      const getSystemPromptFn = () => systemPrompt;
 
       const raw = useNativeTools
         ? await this.aiClient.chatWithSystem(limitedMessages, getSystemPromptFn, sendTools, {

--- a/scripts/core/simulacrum-core.js
+++ b/scripts/core/simulacrum-core.js
@@ -4,7 +4,7 @@
  */
 import { createLogger, isDebugEnabled } from '../utils/logger.js';
 import { AIClient } from './ai-client.js';
-import { ConversationManager, MAX_COMPACTION_ROUNDS } from './conversation.js';
+import { COMPACTION_STATUS, ConversationManager, MAX_COMPACTION_ROUNDS } from './conversation.js';
 import { toolRegistry } from './tool-registry.js';
 import { documentReadRegistry } from '../utils/document-read-registry.js';
 import { toolPermissionManager } from './tool-permission-manager.js';
@@ -457,19 +457,19 @@ class SimulacrumCore {
 
       while (rounds < MAX_COMPACTION_ROUNDS) {
         this._assertPromptFitsContext(promptOverhead);
-        const compacted = await this.conversationManager.compactHistory(
+        const compactionStatus = await this.conversationManager.compactHistory(
           this.aiClient,
           promptOverhead,
           includeRollingSummary
         );
         rounds++;
-        if (
-          !compacted &&
-          this.conversationManager.isWithinCompactionBudget(promptOverhead, includeRollingSummary)
-        ) {
+        if (compactionStatus === COMPACTION_STATUS.WITHIN_BUDGET) {
           break;
         }
-        if (!compacted) continue;
+        if (compactionStatus === COMPACTION_STATUS.FAILED) {
+          this._ensureContextWindowAfterCompactionFailure(promptOverhead, includeRollingSummary);
+          return systemPrompt;
+        }
 
         anyCompacted = true;
         systemPrompt = useCustomPrompt ? systemPrompt : await this.getSystemPrompt();
@@ -507,6 +507,24 @@ class SimulacrumCore {
     if (!this.conversationManager.isWithinCompactionBudget(promptOverhead, includeRollingSummary)) {
       throw new ValidationError(
         'Conversation still exceeds context budget after compaction and truncation',
+        'contextBudget',
+        { promptOverhead, maxTokens: this.conversationManager.maxTokens }
+      );
+    }
+  }
+
+  static _ensureContextWindowAfterCompactionFailure(promptOverhead, includeRollingSummary = true) {
+    this._assertPromptFitsContext(promptOverhead);
+    if (this.conversationManager.isWithinContextWindow(promptOverhead, includeRollingSummary)) {
+      return;
+    }
+
+    this.logger.warn('Compaction failed; truncating oldest conversation history to context window');
+    this.conversationManager.truncateToContextWindow(promptOverhead, includeRollingSummary);
+
+    if (!this.conversationManager.isWithinContextWindow(promptOverhead, includeRollingSummary)) {
+      throw new ValidationError(
+        'Conversation still exceeds context window after failed compaction and truncation',
         'contextBudget',
         { promptOverhead, maxTokens: this.conversationManager.maxTokens }
       );

--- a/scripts/core/simulacrum-core.js
+++ b/scripts/core/simulacrum-core.js
@@ -16,7 +16,6 @@ import {
   sanitizeMessagesForFallback,
 } from '../utils/ai-normalization.js';
 import { smartSliceMessages, formatToolCallDisplay } from '../utils/message-utils.js';
-import { ValidationError } from '../utils/errors.js';
 import { processToolCallLoop } from './tool-loop-handler.js';
 import { emitProcessCancelled } from './hook-manager.js';
 import {
@@ -456,20 +455,13 @@ class SimulacrumCore {
       let promptOverhead = this._estimatePromptOverhead(systemPrompt, includeRollingSummary);
 
       while (rounds < MAX_COMPACTION_ROUNDS) {
-        this._assertPromptFitsContext(promptOverhead);
         const compactionStatus = await this.conversationManager.compactHistory(
           this.aiClient,
-          promptOverhead,
-          includeRollingSummary
+          promptOverhead
         );
         rounds++;
-        if (compactionStatus === COMPACTION_STATUS.WITHIN_BUDGET) {
-          break;
-        }
-        if (compactionStatus === COMPACTION_STATUS.FAILED) {
-          this._ensureContextWindowAfterCompactionFailure(promptOverhead, includeRollingSummary);
-          return systemPrompt;
-        }
+        if (compactionStatus === COMPACTION_STATUS.WITHIN_BUDGET) break;
+        if (compactionStatus === COMPACTION_STATUS.FAILED) break;
 
         anyCompacted = true;
         systemPrompt = useCustomPrompt ? systemPrompt : await this.getSystemPrompt();
@@ -477,62 +469,10 @@ class SimulacrumCore {
       }
 
       if (anyCompacted) this._notifyCompactionOccurred(options);
-      this._ensureConversationFitsAfterCompaction(promptOverhead, includeRollingSummary);
       return systemPrompt;
     } catch (compactionError) {
       this.logger.warn('Compaction failed:', compactionError);
-      throw compactionError;
-    }
-  }
-
-  static _assertPromptFitsContext(promptOverhead) {
-    if (!this.conversationManager.hasAvailableContext(promptOverhead)) {
-      throw new ValidationError(
-        'System prompt exceeds the configured context window before conversation history',
-        'contextBudget',
-        { promptOverhead, maxTokens: this.conversationManager.maxTokens }
-      );
-    }
-  }
-
-  static _ensureConversationFitsAfterCompaction(promptOverhead, includeRollingSummary = true) {
-    this._assertPromptFitsContext(promptOverhead);
-    if (this.conversationManager.isWithinCompactionBudget(promptOverhead, includeRollingSummary)) {
-      return;
-    }
-
-    this.logger.warn('Compaction round limit reached; checking hard context window');
-    if (this.conversationManager.isWithinContextWindow(promptOverhead, includeRollingSummary)) {
-      return;
-    }
-
-    this.logger.warn('Conversation exceeds context window; truncating oldest conversation history');
-    this.conversationManager.truncateToContextWindow(promptOverhead, includeRollingSummary);
-
-    if (!this.conversationManager.isWithinContextWindow(promptOverhead, includeRollingSummary)) {
-      throw new ValidationError(
-        'Conversation still exceeds context window after compaction and truncation',
-        'contextBudget',
-        { promptOverhead, maxTokens: this.conversationManager.maxTokens }
-      );
-    }
-  }
-
-  static _ensureContextWindowAfterCompactionFailure(promptOverhead, includeRollingSummary = true) {
-    this._assertPromptFitsContext(promptOverhead);
-    if (this.conversationManager.isWithinContextWindow(promptOverhead, includeRollingSummary)) {
-      return;
-    }
-
-    this.logger.warn('Compaction failed; truncating oldest conversation history to context window');
-    this.conversationManager.truncateToContextWindow(promptOverhead, includeRollingSummary);
-
-    if (!this.conversationManager.isWithinContextWindow(promptOverhead, includeRollingSummary)) {
-      throw new ValidationError(
-        'Conversation still exceeds context window after failed compaction and truncation',
-        'contextBudget',
-        { promptOverhead, maxTokens: this.conversationManager.maxTokens }
-      );
+      return systemPrompt;
     }
   }
 

--- a/scripts/core/simulacrum-core.js
+++ b/scripts/core/simulacrum-core.js
@@ -4,7 +4,7 @@
  */
 import { createLogger, isDebugEnabled } from '../utils/logger.js';
 import { AIClient } from './ai-client.js';
-import { ConversationManager } from './conversation.js';
+import { ConversationManager, MAX_COMPACTION_ROUNDS } from './conversation.js';
 import { toolRegistry } from './tool-registry.js';
 import { documentReadRegistry } from '../utils/document-read-registry.js';
 import { toolPermissionManager } from './tool-permission-manager.js';
@@ -24,8 +24,6 @@ import {
   getDocumentTypesInfo as getDocTypesInfo,
   getAvailableMacrosList as getMacros,
 } from './system-prompt-builder.js';
-
-const MAX_COMPACTION_ROUNDS = 10;
 
 class SimulacrumCore {
   static logger = createLogger('Core');
@@ -446,8 +444,8 @@ class SimulacrumCore {
     return prompt;
   }
 
-  static _estimatePromptOverhead(systemPrompt, useCustomPrompt) {
-    return this.conversationManager.estimatePromptOverhead(systemPrompt, !useCustomPrompt);
+  static _estimatePromptOverhead(systemPrompt, includeRollingSummary = true) {
+    return this.conversationManager.estimatePromptOverhead(systemPrompt, includeRollingSummary);
   }
 
   static async _compactHistoryIfNeeded(systemPrompt, useCustomPrompt, options) {
@@ -455,7 +453,7 @@ class SimulacrumCore {
       let rounds = 0;
       let anyCompacted = false;
       const includeRollingSummary = !useCustomPrompt;
-      let promptOverhead = this._estimatePromptOverhead(systemPrompt, useCustomPrompt);
+      let promptOverhead = this._estimatePromptOverhead(systemPrompt, includeRollingSummary);
 
       while (rounds < MAX_COMPACTION_ROUNDS) {
         this._assertPromptFitsContext(promptOverhead);
@@ -475,7 +473,7 @@ class SimulacrumCore {
 
         anyCompacted = true;
         systemPrompt = useCustomPrompt ? systemPrompt : await this.getSystemPrompt();
-        promptOverhead = this._estimatePromptOverhead(systemPrompt, useCustomPrompt);
+        promptOverhead = this._estimatePromptOverhead(systemPrompt, includeRollingSummary);
       }
 
       if (anyCompacted) this._notifyCompactionOccurred(options);

--- a/scripts/core/tool-loop-handler.js
+++ b/scripts/core/tool-loop-handler.js
@@ -30,6 +30,7 @@ import { interactionLogger } from './interaction-logger.js';
 const logger = createLogger('ToolLoop');
 const MAX_TOOL_FAILURE_ATTEMPTS = 3;
 const TOOL_RETRY_STATUS_PREFIX = 'tool-retry';
+const MAX_COMPACTION_ROUNDS = 10;
 
 // Store justifications keyed by toolCallId for retrieval when result is ready
 const toolJustifications = new Map();
@@ -770,21 +771,21 @@ async function _promptToolConfirmation(toolName, parsedArgs, toolCallId, context
 async function _getNextAIResponse(toolResults, context) {
   const { getSystemPrompt, conversationManager, aiClient } = context;
 
-  const systemPrompt = await getSystemPrompt();
+  let systemPrompt = await getSystemPrompt();
 
-  // Context Compaction: account for system prompt overhead and loop until under budget
+  // Context Compaction: account for system prompt overhead and loop until within budget
   if (conversationManager && aiClient) {
     try {
-      const systemPromptTokens = conversationManager._estimateTokens({
-        role: 'system',
-        content: systemPrompt,
-      });
-      let compacted = true;
-      while (compacted) {
-        compacted = await conversationManager.compactHistory(aiClient, systemPromptTokens);
-        if (compacted && isDebugEnabled()) {
-          logger.debug('Conversation history compacted during tool loop');
-        }
+      let sysTokens = conversationManager.estimateTokens({ role: 'system', content: systemPrompt });
+      let compacted = await conversationManager.compactHistory(aiClient, sysTokens);
+      let rounds = 0;
+
+      while (compacted && rounds < MAX_COMPACTION_ROUNDS) {
+        rounds++;
+        if (isDebugEnabled()) logger.debug('Conversation history compacted during tool loop');
+        systemPrompt = await getSystemPrompt();
+        sysTokens = conversationManager.estimateTokens({ role: 'system', content: systemPrompt });
+        compacted = await conversationManager.compactHistory(aiClient, sysTokens);
       }
     } catch (err) {
       logger.warn('Compaction failed during tool loop:', err);

--- a/scripts/core/tool-loop-handler.js
+++ b/scripts/core/tool-loop-handler.js
@@ -9,6 +9,7 @@
 import { createLogger, isDebugEnabled } from '../utils/logger.js';
 import { toolRegistry } from './tool-registry.js';
 import { performPostToolVerification } from './tool-verification.js';
+import { MAX_COMPACTION_ROUNDS } from './conversation.js';
 import {
   sanitizeMessagesForFallback,
   normalizeAIResponse,
@@ -31,7 +32,6 @@ import { interactionLogger } from './interaction-logger.js';
 const logger = createLogger('ToolLoop');
 const MAX_TOOL_FAILURE_ATTEMPTS = 3;
 const TOOL_RETRY_STATUS_PREFIX = 'tool-retry';
-const MAX_COMPACTION_ROUNDS = 10;
 
 // Store justifications keyed by toolCallId for retrieval when result is ready
 const toolJustifications = new Map();

--- a/scripts/core/tool-loop-handler.js
+++ b/scripts/core/tool-loop-handler.js
@@ -16,7 +16,6 @@ import {
   parseInlineToolCall,
   repairToolCallArguments,
 } from '../utils/ai-normalization.js';
-import { ValidationError } from '../utils/errors.js';
 import { appendEmptyContentCorrection, appendToolFailureCorrection } from './correction.js';
 import {
   isToolCallFailure,
@@ -781,74 +780,22 @@ async function _getNextAIResponse(toolResults, context) {
       let promptOverhead = conversationManager.estimatePromptOverhead(systemPrompt);
 
       while (rounds < MAX_COMPACTION_ROUNDS) {
-        _assertPromptFitsContext(conversationManager, promptOverhead);
         const compactionStatus = await conversationManager.compactHistory(aiClient, promptOverhead);
         rounds++;
         if (compactionStatus === COMPACTION_STATUS.WITHIN_BUDGET) break;
-        if (compactionStatus === COMPACTION_STATUS.FAILED) {
-          _ensureContextWindowAfterCompactionFailure(conversationManager, promptOverhead);
-          break;
-        }
+        if (compactionStatus === COMPACTION_STATUS.FAILED) break;
 
         if (isDebugEnabled()) logger.debug('Conversation history compacted during tool loop');
         systemPrompt = await getSystemPrompt();
         promptOverhead = conversationManager.estimatePromptOverhead(systemPrompt);
       }
-
-      _ensureConversationFitsAfterCompaction(conversationManager, promptOverhead);
     } catch (err) {
       logger.warn('Compaction failed during tool loop:', err);
-      throw err;
     }
   }
 
   const messages = _getConversationMessages(context);
   return _chatWithAI(messages, systemPrompt, context);
-}
-
-function _assertPromptFitsContext(conversationManager, promptOverhead) {
-  if (!conversationManager.hasAvailableContext(promptOverhead)) {
-    throw new ValidationError(
-      'System prompt exceeds the configured context window before conversation history',
-      'contextBudget',
-      { promptOverhead, maxTokens: conversationManager.maxTokens }
-    );
-  }
-}
-
-function _ensureConversationFitsAfterCompaction(conversationManager, promptOverhead) {
-  _assertPromptFitsContext(conversationManager, promptOverhead);
-  if (conversationManager.isWithinCompactionBudget(promptOverhead)) return;
-
-  logger.warn('Compaction round limit reached; checking hard context window');
-  if (conversationManager.isWithinContextWindow(promptOverhead)) return;
-
-  logger.warn('Conversation exceeds context window; truncating oldest conversation history');
-  conversationManager.truncateToContextWindow(promptOverhead);
-
-  if (!conversationManager.isWithinContextWindow(promptOverhead)) {
-    throw new ValidationError(
-      'Conversation still exceeds context window after compaction and truncation',
-      'contextBudget',
-      { promptOverhead, maxTokens: conversationManager.maxTokens }
-    );
-  }
-}
-
-function _ensureContextWindowAfterCompactionFailure(conversationManager, promptOverhead) {
-  _assertPromptFitsContext(conversationManager, promptOverhead);
-  if (conversationManager.isWithinContextWindow(promptOverhead)) return;
-
-  logger.warn('Compaction failed; truncating oldest conversation history to context window');
-  conversationManager.truncateToContextWindow(promptOverhead);
-
-  if (!conversationManager.isWithinContextWindow(promptOverhead)) {
-    throw new ValidationError(
-      'Conversation still exceeds context window after failed compaction and truncation',
-      'contextBudget',
-      { promptOverhead, maxTokens: conversationManager.maxTokens }
-    );
-  }
 }
 
 // --- Utilities ---

--- a/scripts/core/tool-loop-handler.js
+++ b/scripts/core/tool-loop-handler.js
@@ -776,24 +776,47 @@ async function _getNextAIResponse(toolResults, context) {
   // Context Compaction: account for system prompt overhead and loop until within budget
   if (conversationManager && aiClient) {
     try {
-      let sysTokens = conversationManager.estimateTokens({ role: 'system', content: systemPrompt });
-      let compacted = await conversationManager.compactHistory(aiClient, sysTokens);
       let rounds = 0;
+      let promptOverhead = conversationManager.estimatePromptOverhead(systemPrompt);
 
-      while (compacted && rounds < MAX_COMPACTION_ROUNDS) {
+      while (rounds < MAX_COMPACTION_ROUNDS) {
+        _assertPromptFitsContext(conversationManager, promptOverhead);
+        const compacted = await conversationManager.compactHistory(aiClient, promptOverhead);
         rounds++;
+        if (!compacted) break;
+
         if (isDebugEnabled()) logger.debug('Conversation history compacted during tool loop');
         systemPrompt = await getSystemPrompt();
-        sysTokens = conversationManager.estimateTokens({ role: 'system', content: systemPrompt });
-        compacted = await conversationManager.compactHistory(aiClient, sysTokens);
+        promptOverhead = conversationManager.estimatePromptOverhead(systemPrompt);
       }
+
+      _ensureConversationFitsAfterCompaction(conversationManager, promptOverhead);
     } catch (err) {
       logger.warn('Compaction failed during tool loop:', err);
+      throw err;
     }
   }
 
   const messages = _getConversationMessages(context);
   return _chatWithAI(messages, systemPrompt, context);
+}
+
+function _assertPromptFitsContext(conversationManager, promptOverhead) {
+  if (!conversationManager.hasAvailableContext(promptOverhead)) {
+    throw new Error('System prompt exceeds the configured context window before conversation history');
+  }
+}
+
+function _ensureConversationFitsAfterCompaction(conversationManager, promptOverhead) {
+  _assertPromptFitsContext(conversationManager, promptOverhead);
+  if (conversationManager.isWithinCompactionBudget(promptOverhead)) return;
+
+  logger.warn('Compaction round limit reached; truncating oldest conversation history');
+  conversationManager.truncateToCompactionBudget(promptOverhead);
+
+  if (!conversationManager.isWithinCompactionBudget(promptOverhead)) {
+    throw new Error('Conversation still exceeds context budget after compaction and truncation');
+  }
 }
 
 // --- Utilities ---

--- a/scripts/core/tool-loop-handler.js
+++ b/scripts/core/tool-loop-handler.js
@@ -784,7 +784,8 @@ async function _getNextAIResponse(toolResults, context) {
         _assertPromptFitsContext(conversationManager, promptOverhead);
         const compacted = await conversationManager.compactHistory(aiClient, promptOverhead);
         rounds++;
-        if (!compacted) break;
+        if (!compacted && conversationManager.isWithinCompactionBudget(promptOverhead)) break;
+        if (!compacted) continue;
 
         if (isDebugEnabled()) logger.debug('Conversation history compacted during tool loop');
         systemPrompt = await getSystemPrompt();

--- a/scripts/core/tool-loop-handler.js
+++ b/scripts/core/tool-loop-handler.js
@@ -9,7 +9,7 @@
 import { createLogger, isDebugEnabled } from '../utils/logger.js';
 import { toolRegistry } from './tool-registry.js';
 import { performPostToolVerification } from './tool-verification.js';
-import { MAX_COMPACTION_ROUNDS } from './conversation.js';
+import { COMPACTION_STATUS, MAX_COMPACTION_ROUNDS } from './conversation.js';
 import {
   sanitizeMessagesForFallback,
   normalizeAIResponse,
@@ -782,10 +782,13 @@ async function _getNextAIResponse(toolResults, context) {
 
       while (rounds < MAX_COMPACTION_ROUNDS) {
         _assertPromptFitsContext(conversationManager, promptOverhead);
-        const compacted = await conversationManager.compactHistory(aiClient, promptOverhead);
+        const compactionStatus = await conversationManager.compactHistory(aiClient, promptOverhead);
         rounds++;
-        if (!compacted && conversationManager.isWithinCompactionBudget(promptOverhead)) break;
-        if (!compacted) continue;
+        if (compactionStatus === COMPACTION_STATUS.WITHIN_BUDGET) break;
+        if (compactionStatus === COMPACTION_STATUS.FAILED) {
+          _ensureContextWindowAfterCompactionFailure(conversationManager, promptOverhead);
+          break;
+        }
 
         if (isDebugEnabled()) logger.debug('Conversation history compacted during tool loop');
         systemPrompt = await getSystemPrompt();
@@ -823,6 +826,22 @@ function _ensureConversationFitsAfterCompaction(conversationManager, promptOverh
   if (!conversationManager.isWithinCompactionBudget(promptOverhead)) {
     throw new ValidationError(
       'Conversation still exceeds context budget after compaction and truncation',
+      'contextBudget',
+      { promptOverhead, maxTokens: conversationManager.maxTokens }
+    );
+  }
+}
+
+function _ensureContextWindowAfterCompactionFailure(conversationManager, promptOverhead) {
+  _assertPromptFitsContext(conversationManager, promptOverhead);
+  if (conversationManager.isWithinContextWindow(promptOverhead)) return;
+
+  logger.warn('Compaction failed; truncating oldest conversation history to context window');
+  conversationManager.truncateToContextWindow(promptOverhead);
+
+  if (!conversationManager.isWithinContextWindow(promptOverhead)) {
+    throw new ValidationError(
+      'Conversation still exceeds context window after failed compaction and truncation',
       'contextBudget',
       { promptOverhead, maxTokens: conversationManager.maxTokens }
     );

--- a/scripts/core/tool-loop-handler.js
+++ b/scripts/core/tool-loop-handler.js
@@ -15,6 +15,7 @@ import {
   parseInlineToolCall,
   repairToolCallArguments,
 } from '../utils/ai-normalization.js';
+import { ValidationError } from '../utils/errors.js';
 import { appendEmptyContentCorrection, appendToolFailureCorrection } from './correction.js';
 import {
   isToolCallFailure,
@@ -803,7 +804,11 @@ async function _getNextAIResponse(toolResults, context) {
 
 function _assertPromptFitsContext(conversationManager, promptOverhead) {
   if (!conversationManager.hasAvailableContext(promptOverhead)) {
-    throw new Error('System prompt exceeds the configured context window before conversation history');
+    throw new ValidationError(
+      'System prompt exceeds the configured context window before conversation history',
+      'contextBudget',
+      { promptOverhead, maxTokens: conversationManager.maxTokens }
+    );
   }
 }
 
@@ -815,7 +820,11 @@ function _ensureConversationFitsAfterCompaction(conversationManager, promptOverh
   conversationManager.truncateToCompactionBudget(promptOverhead);
 
   if (!conversationManager.isWithinCompactionBudget(promptOverhead)) {
-    throw new Error('Conversation still exceeds context budget after compaction and truncation');
+    throw new ValidationError(
+      'Conversation still exceeds context budget after compaction and truncation',
+      'contextBudget',
+      { promptOverhead, maxTokens: conversationManager.maxTokens }
+    );
   }
 }
 

--- a/scripts/core/tool-loop-handler.js
+++ b/scripts/core/tool-loop-handler.js
@@ -820,12 +820,15 @@ function _ensureConversationFitsAfterCompaction(conversationManager, promptOverh
   _assertPromptFitsContext(conversationManager, promptOverhead);
   if (conversationManager.isWithinCompactionBudget(promptOverhead)) return;
 
-  logger.warn('Compaction round limit reached; truncating oldest conversation history');
-  conversationManager.truncateToCompactionBudget(promptOverhead);
+  logger.warn('Compaction round limit reached; checking hard context window');
+  if (conversationManager.isWithinContextWindow(promptOverhead)) return;
 
-  if (!conversationManager.isWithinCompactionBudget(promptOverhead)) {
+  logger.warn('Conversation exceeds context window; truncating oldest conversation history');
+  conversationManager.truncateToContextWindow(promptOverhead);
+
+  if (!conversationManager.isWithinContextWindow(promptOverhead)) {
     throw new ValidationError(
-      'Conversation still exceeds context budget after compaction and truncation',
+      'Conversation still exceeds context window after compaction and truncation',
       'contextBudget',
       { promptOverhead, maxTokens: conversationManager.maxTokens }
     );

--- a/scripts/core/tool-loop-handler.js
+++ b/scripts/core/tool-loop-handler.js
@@ -770,12 +770,21 @@ async function _promptToolConfirmation(toolName, parsedArgs, toolCallId, context
 async function _getNextAIResponse(toolResults, context) {
   const { getSystemPrompt, conversationManager, aiClient } = context;
 
-  // Context Compaction: Trigger before next AI call
+  const systemPrompt = await getSystemPrompt();
+
+  // Context Compaction: account for system prompt overhead and loop until under budget
   if (conversationManager && aiClient) {
     try {
-      const compacted = await conversationManager.compactHistory(aiClient);
-      if (compacted && isDebugEnabled()) {
-        logger.debug('Conversation history compacted during tool loop');
+      const systemPromptTokens = conversationManager._estimateTokens({
+        role: 'system',
+        content: systemPrompt,
+      });
+      let compacted = true;
+      while (compacted) {
+        compacted = await conversationManager.compactHistory(aiClient, systemPromptTokens);
+        if (compacted && isDebugEnabled()) {
+          logger.debug('Conversation history compacted during tool loop');
+        }
       }
     } catch (err) {
       logger.warn('Compaction failed during tool loop:', err);
@@ -783,7 +792,6 @@ async function _getNextAIResponse(toolResults, context) {
   }
 
   const messages = _getConversationMessages(context);
-  const systemPrompt = await getSystemPrompt();
   return _chatWithAI(messages, systemPrompt, context);
 }
 

--- a/scripts/ui/simulacrum-sidebar-tab.js
+++ b/scripts/ui/simulacrum-sidebar-tab.js
@@ -1369,11 +1369,8 @@ export class SimulacrumSidebarTab extends HandlebarsApplicationMixin(AbstractSid
   async _saveContextLimit(value) {
     const limit = this._parseContextLimit(value);
     if (limit) {
+      // Update fallback setting
       await game.settings.set('simulacrum', 'fallbackContextLimit', limit);
-      // Propagate to the running ConversationManager so compaction uses the new limit immediately
-      if (SimulacrumCore.conversationManager) {
-        SimulacrumCore.conversationManager.maxTokens = limit;
-      }
       this.logger.info(`Context limit updated to: ${limit}`);
     }
   }

--- a/scripts/ui/simulacrum-sidebar-tab.js
+++ b/scripts/ui/simulacrum-sidebar-tab.js
@@ -1369,8 +1369,11 @@ export class SimulacrumSidebarTab extends HandlebarsApplicationMixin(AbstractSid
   async _saveContextLimit(value) {
     const limit = this._parseContextLimit(value);
     if (limit) {
-      // Update fallback setting
       await game.settings.set('simulacrum', 'fallbackContextLimit', limit);
+      // Propagate to the running ConversationManager so compaction uses the new limit immediately
+      if (SimulacrumCore.conversationManager) {
+        SimulacrumCore.conversationManager.maxTokens = limit;
+      }
       this.logger.info(`Context limit updated to: ${limit}`);
     }
   }

--- a/tests/utils/test-compaction-budget.mjs
+++ b/tests/utils/test-compaction-budget.mjs
@@ -23,21 +23,22 @@ function testPromptOverheadDoesNotDoubleCountRollingSummary() {
   const basePrompt = 'base system prompt';
   const systemPrompt = `### PREVIOUS CONVERSATION SUMMARY\n${conversation.rollingSummary}\n\n${basePrompt}`;
   const fullPromptTokens = conversation.estimateTokens({ role: 'system', content: systemPrompt });
+  const summaryTokens = conversation.estimateTokens({ role: 'system', content: conversation.rollingSummary });
 
-  assert.equal(conversation.getSessionTokens(), 25);
-  assert.equal(conversation.estimatePromptOverhead(systemPrompt), fullPromptTokens - 25);
+  assert.equal(conversation.estimatePromptOverhead(systemPrompt), fullPromptTokens - summaryTokens);
 }
 
-function testCustomPromptBudgetDoesNotCountUnsentRollingSummary() {
+function testCustomPromptOverheadExcludesRollingSummary() {
   const conversation = createConversation(600);
-  conversation.rollingSummary = 'a'.repeat(2000);
+  conversation.rollingSummary = 'a'.repeat(200);
   conversation._recalculateTokens();
 
   const customPrompt = 'short custom prompt';
-  const promptOverhead = conversation.estimatePromptOverhead(customPrompt, false);
+  const overheadWithSummary = conversation.estimatePromptOverhead(customPrompt, true);
+  const overheadWithoutSummary = conversation.estimatePromptOverhead(customPrompt, false);
 
-  assert.equal(conversation.isWithinCompactionBudget(promptOverhead, true), false);
-  assert.equal(conversation.isWithinCompactionBudget(promptOverhead, false), true);
+  // Without summary subtraction, overhead should be higher (or equal if summary not in prompt)
+  assert.ok(overheadWithoutSummary >= overheadWithSummary);
 }
 
 function testThresholdIsClampedWhenPromptConsumesContext() {
@@ -45,35 +46,16 @@ function testThresholdIsClampedWhenPromptConsumesContext() {
 
   assert.equal(conversation._getCompactionThreshold(100), 0);
   assert.equal(conversation._getCompactionThreshold(150), 0);
-  assert.equal(conversation.hasAvailableContext(100), false);
 }
 
-function testTruncateToCompactionBudgetDropsOldestMessages() {
+async function testCompactionWithinBudgetReturnsWithinBudget() {
   const conversation = createConversation(1000);
-  for (let i = 0; i < 10; i++) {
-    conversation.addMessage('user', `${i}: ${'x'.repeat(100)}`);
-  }
+  conversation.addMessage('user', 'short message');
 
-  assert.equal(conversation.isWithinCompactionBudget(0), false);
+  const mockClient = { async chat() { throw new Error('should not be called'); } };
+  const status = await conversation.compactHistory(mockClient, 0);
 
-  const changed = conversation.truncateToCompactionBudget(0);
-
-  assert.equal(changed, true);
-  assert.equal(conversation.isWithinCompactionBudget(0), true);
-  assert.equal(conversation.getMessages()[0].content.startsWith('0:'), false);
-}
-
-function testContextWindowAllowsConservativeBudgetOverflow() {
-  const conversation = createConversation(1000);
-  conversation.addMessage('user', 'x'.repeat(800));
-
-  assert.equal(conversation.isWithinCompactionBudget(0), false);
-  assert.equal(conversation.isWithinContextWindow(0), true);
-
-  const changed = conversation.truncateToContextWindow(0);
-
-  assert.equal(changed, false);
-  assert.equal(conversation.getMessages().length, 1);
+  assert.equal(status, COMPACTION_STATUS.WITHIN_BUDGET);
 }
 
 async function testCompactionFailureReturnsExplicitStatus() {
@@ -94,10 +76,9 @@ async function testCompactionFailureReturnsExplicitStatus() {
 }
 
 testPromptOverheadDoesNotDoubleCountRollingSummary();
-testCustomPromptBudgetDoesNotCountUnsentRollingSummary();
+testCustomPromptOverheadExcludesRollingSummary();
 testThresholdIsClampedWhenPromptConsumesContext();
-testTruncateToCompactionBudgetDropsOldestMessages();
-testContextWindowAllowsConservativeBudgetOverflow();
+await testCompactionWithinBudgetReturnsWithinBudget();
 await testCompactionFailureReturnsExplicitStatus();
 
 console.log('compaction budget tests passed');

--- a/tests/utils/test-compaction-budget.mjs
+++ b/tests/utils/test-compaction-budget.mjs
@@ -63,6 +63,19 @@ function testTruncateToCompactionBudgetDropsOldestMessages() {
   assert.equal(conversation.getMessages()[0].content.startsWith('0:'), false);
 }
 
+function testContextWindowAllowsConservativeBudgetOverflow() {
+  const conversation = createConversation(1000);
+  conversation.addMessage('user', 'x'.repeat(800));
+
+  assert.equal(conversation.isWithinCompactionBudget(0), false);
+  assert.equal(conversation.isWithinContextWindow(0), true);
+
+  const changed = conversation.truncateToContextWindow(0);
+
+  assert.equal(changed, false);
+  assert.equal(conversation.getMessages().length, 1);
+}
+
 async function testCompactionFailureReturnsExplicitStatus() {
   const conversation = createConversation(1000);
   for (let i = 0; i < 10; i++) {
@@ -84,6 +97,7 @@ testPromptOverheadDoesNotDoubleCountRollingSummary();
 testCustomPromptBudgetDoesNotCountUnsentRollingSummary();
 testThresholdIsClampedWhenPromptConsumesContext();
 testTruncateToCompactionBudgetDropsOldestMessages();
+testContextWindowAllowsConservativeBudgetOverflow();
 await testCompactionFailureReturnsExplicitStatus();
 
 console.log('compaction budget tests passed');

--- a/tests/utils/test-compaction-budget.mjs
+++ b/tests/utils/test-compaction-budget.mjs
@@ -2,7 +2,8 @@ import assert from 'node:assert/strict';
 
 globalThis.FormApplication = class {};
 
-const { ConversationManager } = await import('../../scripts/core/conversation.js');
+const { COMPACTION_STATUS, ConversationManager } =
+  await import('../../scripts/core/conversation.js');
 
 const tokenizer = {
   estimateMessageTokens(message) {
@@ -62,9 +63,27 @@ function testTruncateToCompactionBudgetDropsOldestMessages() {
   assert.equal(conversation.getMessages()[0].content.startsWith('0:'), false);
 }
 
+async function testCompactionFailureReturnsExplicitStatus() {
+  const conversation = createConversation(1000);
+  for (let i = 0; i < 10; i++) {
+    conversation.addMessage('user', `${i}: ${'x'.repeat(100)}`);
+  }
+
+  const failingClient = {
+    async chat() {
+      throw new Error('background compaction unavailable');
+    },
+  };
+
+  const status = await conversation.compactHistory(failingClient, 0);
+
+  assert.equal(status, COMPACTION_STATUS.FAILED);
+}
+
 testPromptOverheadDoesNotDoubleCountRollingSummary();
 testCustomPromptBudgetDoesNotCountUnsentRollingSummary();
 testThresholdIsClampedWhenPromptConsumesContext();
 testTruncateToCompactionBudgetDropsOldestMessages();
+await testCompactionFailureReturnsExplicitStatus();
 
 console.log('compaction budget tests passed');

--- a/tests/utils/test-compaction-budget.mjs
+++ b/tests/utils/test-compaction-budget.mjs
@@ -1,0 +1,57 @@
+import assert from 'node:assert/strict';
+
+globalThis.FormApplication = class {};
+
+const { ConversationManager } = await import('../../scripts/core/conversation.js');
+
+const tokenizer = {
+  estimateMessageTokens(message) {
+    return Math.ceil(String(message?.content || '').length / 4);
+  },
+};
+
+function createConversation(maxTokens = 1000) {
+  return new ConversationManager('test-user', 'test-world', maxTokens, tokenizer);
+}
+
+function testPromptOverheadDoesNotDoubleCountRollingSummary() {
+  const conversation = createConversation();
+  conversation.rollingSummary = 'a'.repeat(100);
+  conversation._recalculateTokens();
+
+  const basePrompt = 'base system prompt';
+  const systemPrompt = `### PREVIOUS CONVERSATION SUMMARY\n${conversation.rollingSummary}\n\n${basePrompt}`;
+  const fullPromptTokens = conversation.estimateTokens({ role: 'system', content: systemPrompt });
+
+  assert.equal(conversation.getSessionTokens(), 25);
+  assert.equal(conversation.estimatePromptOverhead(systemPrompt), fullPromptTokens - 25);
+}
+
+function testThresholdIsClampedWhenPromptConsumesContext() {
+  const conversation = createConversation(100);
+
+  assert.equal(conversation._getCompactionThreshold(100), 0);
+  assert.equal(conversation._getCompactionThreshold(150), 0);
+  assert.equal(conversation.hasAvailableContext(100), false);
+}
+
+function testTruncateToCompactionBudgetDropsOldestMessages() {
+  const conversation = createConversation(1000);
+  for (let i = 0; i < 10; i++) {
+    conversation.addMessage('user', `${i}: ${'x'.repeat(100)}`);
+  }
+
+  assert.equal(conversation.isWithinCompactionBudget(0), false);
+
+  const changed = conversation.truncateToCompactionBudget(0);
+
+  assert.equal(changed, true);
+  assert.equal(conversation.isWithinCompactionBudget(0), true);
+  assert.equal(conversation.getMessages()[0].content.startsWith('0:'), false);
+}
+
+testPromptOverheadDoesNotDoubleCountRollingSummary();
+testThresholdIsClampedWhenPromptConsumesContext();
+testTruncateToCompactionBudgetDropsOldestMessages();
+
+console.log('compaction budget tests passed');

--- a/tests/utils/test-compaction-budget.mjs
+++ b/tests/utils/test-compaction-budget.mjs
@@ -27,6 +27,18 @@ function testPromptOverheadDoesNotDoubleCountRollingSummary() {
   assert.equal(conversation.estimatePromptOverhead(systemPrompt), fullPromptTokens - 25);
 }
 
+function testCustomPromptBudgetDoesNotCountUnsentRollingSummary() {
+  const conversation = createConversation(600);
+  conversation.rollingSummary = 'a'.repeat(2000);
+  conversation._recalculateTokens();
+
+  const customPrompt = 'short custom prompt';
+  const promptOverhead = conversation.estimatePromptOverhead(customPrompt, false);
+
+  assert.equal(conversation.isWithinCompactionBudget(promptOverhead, true), false);
+  assert.equal(conversation.isWithinCompactionBudget(promptOverhead, false), true);
+}
+
 function testThresholdIsClampedWhenPromptConsumesContext() {
   const conversation = createConversation(100);
 
@@ -51,6 +63,7 @@ function testTruncateToCompactionBudgetDropsOldestMessages() {
 }
 
 testPromptOverheadDoesNotDoubleCountRollingSummary();
+testCustomPromptBudgetDoesNotCountUnsentRollingSummary();
 testThresholdIsClampedWhenPromptConsumesContext();
 testTruncateToCompactionBudgetDropsOldestMessages();
 


### PR DESCRIPTION
## Summary

- `compactHistory` previously ran at most once per request. If one round was not enough to reduce the conversation below budget, the full oversized history was still sent to the provider.
- The compaction threshold was calculated from conversation tokens only, ignoring system prompt size. A large system prompt could push the total request over the provider context limit even when conversation tokens appeared under threshold.

## Changes

- `_getCompactionThreshold(overhead)` and `compactHistory(aiClient, overhead)` account for non-conversation prompt overhead.
- System prompt overhead excludes rolling-summary tokens already represented in `sessionTokens`, avoiding double-counting.
- Custom system prompts are budgeted without counting rolling-summary tokens that are not sent with the custom prompt.
- `compactHistory()` now returns explicit statuses for `within_budget`, `compacted`, and `failed`, so callers do not conflate successful no-op with failed summarization.
- Both AI call paths share one compaction-round policy, refresh prompts after successful compaction, and avoid retry storms when background summarization is hard-failing.
- Failed compaction and exhausted compaction rounds fall back to the hard provider context-window limit instead of treating the conservative compaction target as a send-time requirement.
- Compaction UI notifications are best-effort and no longer turn display/callback failures into chat failures.
- Context-budget failures now use typed `ValidationError`s before issuing oversized provider requests.
- Conversation sanitization owns its own token recalculation and reports whether it changed history, avoiding duplicate recalculation in truncation loops.

## Empirical Verification (UTRs)

```text
$ node tests/utils/test-compaction-budget.mjs
[Simulacrum:Conversation] Conversation history truncated after compaction round limit
[Simulacrum:Conversation] Compaction failed: Error: background compaction unavailable
    at Object.chat (file:///home/agent/projects/simulacrum-foundry/tests/utils/test-compaction-budget.mjs:87:13)
    at ConversationManager.compactHistory (file:///home/agent/projects/simulacrum-foundry/scripts/core/conversation.js:295:39)
    at testCompactionFailureReturnsExplicitStatus (file:///home/agent/projects/simulacrum-foundry/tests/utils/test-compaction-budget.mjs:91:37)
    at file:///home/agent/projects/simulacrum-foundry/tests/utils/test-compaction-budget.mjs:101:7
compaction budget tests passed
```

```text
$ npx eslint scripts/core/conversation.js scripts/core/simulacrum-core.js scripts/core/tool-loop-handler.js
<no output; exit code 0>
```

```text
$ npx prettier --check scripts/core/conversation.js scripts/core/simulacrum-core.js scripts/core/tool-loop-handler.js tests/utils/test-compaction-budget.mjs
Checking formatting...
All matched files use Prettier code style!
```

```text
$ npm run test:repair

> simulacrum@1.0.1 test:repair
> node tests/utils/test-repair.mjs

--- Testing repairToolCallArguments ---
Issue #145 Truncated: PASS (ok=true repaired=true)
Empty String: PASS (ok=false repaired=false)
Whitespace Only: PASS (ok=false repaired=false)
Null Literal: PASS (ok=true repaired=false)
Number Literal: PASS (ok=true repaired=false)

--- Testing normalizeToolCallArguments ---
Repaired JSON: PASS
[Simulacrum:AIDiagnostics] tool_call.args.unrecoverable { name: 'test', error: 'Empty tool call arguments' }
Empty String Sentinel: PASS

7 passed, 0 failed
```

```text
$ git diff --check
<no output; exit code 0>
```

```text
$ gh pr checks 151 --repo Daxiongmao87/simulacrum-foundry
GitGuardian Security Checks  pass
Lint & Format                pass
```

🤖 Generated with [Claude Code](https://claude.com/claude-code)
