### PR TITLE
fix(ui): render sidebar tab on FoundryVTT v14 (Fixes #136)

### DIFF
--- a/scripts/ui/simulacrum-sidebar-tab.js
+++ b/scripts/ui/simulacrum-sidebar-tab.js
@@ -365,7 +365,11 @@ export class SimulacrumSidebarTab extends HandlebarsApplicationMixin(AbstractSid
 
     // SECURITY: Defensive check - GM-only access
     if (!game.user?.isGM) {
-      return foundry.utils.mergeObject(context, {
+      // NOTE: Use Object.assign (shallow), NOT foundry.utils.mergeObject. On v14 the base
+      // AbstractSidebarTab._prepareContext already places the User document at context.user,
+      // so a recursive merge of { user: game.user } recurses into the Document and throws
+      // "Cannot assign to read only property '_id'", aborting the render (blank tab, #136).
+      return Object.assign(context, {
         messages: [],
         welcomeMessage: null,
         isGM: false,
@@ -398,7 +402,8 @@ export class SimulacrumSidebarTab extends HandlebarsApplicationMixin(AbstractSid
       );
     }
 
-    return foundry.utils.mergeObject(context, {
+    // Object.assign (shallow) — see note in the GM-gate branch above re: mergeObject + User._id.
+    return Object.assign(context, {
       messages: this.messages,
       isGM: game.user.isGM,
       user: game.user,


### PR DESCRIPTION
On v14 the sidebar tab opened completely blank. AbstractSidebarTab's render aborted in _prepareContext with:

  TypeError: Cannot assign to read only property '_id' of object '#<User>'
    at foundry.utils.mergeObject
    at SimulacrumSidebarTab._prepareContext


v14's base `AbstractSidebarTab._prepareContext` now seeds `context.user` with the current `User` document. The override then deep-merged a second `{ user: game.user }` over it with `foundry.utils.mergeObject`, which recurses into the live Document and tries to overwrite its read-only `_id` — throwing and aborting the whole tab render. v13 didn't seed `context.user`, so the merge never recursed.

Switched both context returns in `_prepareContext` to `Object.assign` (shallow), which sets the top-level keys without recursing into the Document. Behaviourally identical on v13.

**Verified** on FoundryVTT v14 build 359, dnd5e world: tab now renders the welcome message, model selector, and input box.

<img width="446" height="1406" alt="image" src="https://github.com/user-attachments/assets/9ac29843-6b43-4dea-b98c-d96907beb98c" />


## Empirical Verification (UTRs)

No automated test suite covers runtime browser behavior in this module (the Playwright e2e harness is present but contains no spec files, so there is no existing CI coverage for sidebar rendering).

Fix verified empirically by running the module live:

**Environment:** FoundryVTT v14 (build 359), dnd5e system, Simulacrum installed from this branch.

**Before fix:**
```
TypeError: Cannot assign to read only property '_id' of object '#<User5e>'
    at foundry.utils.mergeObject (foundry-esm.js)
    at SimulacrumSidebarTab._prepareContext (simulacrum-sidebar-tab.js)
```
Sidebar tab rendered completely blank — no content, no console-visible UI.

**After fix:**
Sidebar tab renders correctly: welcome message, model selector, and chat input box all visible. No errors in console. See screenshot in PR description above (captured post-fix).

**Backward compatibility:** `Object.assign` is a strict subset of what `mergeObject` did for non-Document plain objects at the top level (both set the same keys to the same values when there's no nested-object recursion involved). On v13, `context.user` was not pre-seeded by the base class, so the original `mergeObject` call never recursed into a Document there either — behavior is unchanged.

