### PR TITLE
Prepare 1.1.0 release workflow

### DIFF
--- a/.github/workflows/create-release.yml
+++ b/.github/workflows/create-release.yml
@@ -3,7 +3,7 @@
 
 name: Create Release
 
-"on":
+'on':
   workflow_dispatch:
     inputs:
       version:
@@ -91,54 +91,42 @@ jobs:
           cd ..
           mv module.json.release module.json
 
-      - name: Generate changelog
+      - name: Verify changelog entry exists
         id: changelog
         run: |
           VERSION=${{ steps.version.outputs.version }}
-          TODAY=$(date +%Y-%m-%d)
-          PREV_TAG=$(git describe --tags --abbrev=0 HEAD 2>/dev/null || echo "")
-          if [ -n "$PREV_TAG" ]; then
-            echo "Generating changelog from $PREV_TAG to HEAD"
-            COMMITS=$(git log --pretty=format:"- %s" $PREV_TAG..HEAD | grep -vE '^- (docs|ci|chore):')
-          else
-            echo "No previous tag found, including recent commits"
-            COMMITS=$(git log --pretty=format:"- %s" HEAD~10..HEAD 2>/dev/null || git log --pretty=format:"- %s" | grep -vE '^- (docs|ci|chore):')
+          if ! grep -q "^## \[${VERSION}\]" CHANGELOG.md; then
+            echo "::error::CHANGELOG.md is missing entry for version ${VERSION}"
+            echo "Expected heading: ## [${VERSION}]"
+            exit 1
           fi
-          # Ensure we have at least something for the changelog
-          if [ -z "$COMMITS" ]; then
-            COMMITS="- Maintenance release"
+          echo "Changelog entry for ${VERSION} found"
+
+      - name: Extract changelog body for release
+        run: |
+          VERSION=${{ steps.version.outputs.version }}
+          # Extract lines after the version heading until the next heading or end of file
+          awk "/^## \[${VERSION}\]/{found=1; next} /^## \[[0-9]/{exit} found{print}" CHANGELOG.md > changelog.txt
+          if [ ! -s changelog.txt ]; then
+            echo "::error::Changelog body for ${VERSION} is empty"
+            exit 1
           fi
-          echo "$COMMITS" > changelog.txt
-          cat > new_entry.txt << 'ENTRY_EOF'
-          ## [$VERSION] - $TODAY
+          echo "Extracted changelog body:"
+          cat changelog.txt
 
-          ### Changed
-          ENTRY_EOF
-          sed -i "s/\$VERSION/$VERSION/g; s/\$TODAY/$TODAY/g" new_entry.txt
-          echo "$COMMITS" >> new_entry.txt
-          head -n 7 CHANGELOG.md > CHANGELOG.tmp
-          echo "" >> CHANGELOG.tmp
-          cat new_entry.txt >> CHANGELOG.tmp
-          tail -n +8 CHANGELOG.md >> CHANGELOG.tmp
-          mv CHANGELOG.tmp CHANGELOG.md
-          rm new_entry.txt
-
-      - name: Commit CHANGELOG.md and create tag
+      - name: Create and push release tag
         run: |
           VERSION=${{ steps.version.outputs.version }}
           git config user.name "github-actions[bot]"
           git config user.email "github-actions[bot]@users.noreply.github.com"
-          git add CHANGELOG.md
-          git commit -m "docs: update CHANGELOG.md for ${VERSION}" || echo "No changes to commit"
           git tag -a "${VERSION}" -m "Release ${VERSION}"
-          git push origin main
           git push origin "${VERSION}"
 
       - name: Create GitHub Release
         uses: softprops/action-gh-release@v1
         with:
           tag_name: ${{ steps.version.outputs.version }}
-          name: "v${{ steps.version.outputs.version }}"
+          name: 'v${{ steps.version.outputs.version }}'
           body_path: changelog.txt
           files: |
             module.json

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,10 +5,19 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [1.1.0] - 2026-06-12
+
+### Changed
+
+- feat(compat): add Foundry v14 support by fixing sidebar rendering
+- fix(chat): fix message cancellation race-condition cascade
+- fix(ai): honor context limit in compaction to prevent overflow
+- fix(tools): ensure outgoing tool call arguments are valid JSON
 
 ## [1.0.9] - 2026-03-18
 
 ### Changed
+
 - refactor: remove maxResults caps and merge compendium management into document tools
 - feat: add document copy and move tools
 - feat: add compendium create action and rename pack_id to packId
@@ -22,6 +31,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ## [1.0.8] - 2026-02-08
 
 ### Changed
+
 - refactor(benchmark): replace webhook with guided Discord sharing flow
 - chore(benchmark): switch webhook to public channel, drop review language
 - fix(benchmark): note that Discord submissions are reviewed
@@ -53,14 +63,16 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ## [1.0.7] - 2026-02-06
 
 ### Changed
+
 - fix: Ollama integration - race conditions, non-blocking validation, token limit consolidation
 - fix(ci): Fix shell quoting in Discord announcement step
 
 ## [1.0.6] - 2026-02-05
 
 ### Changed
+
 - fix(ui): Restore status bar styling and task tracker regressions
-- fix(ui): Remove leftover _monitorStatus call causing crash
+- fix(ui): Remove leftover \_monitorStatus call causing crash
 - fix(ui): Restore status bar and indexing status logic
 - feat: Add context limit handling and sidebar UI refinements
 - fix: restore tool justification expand/collapse functionality
@@ -75,6 +87,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ## [1.0.5] - 2026-02-03
 
 ### Changed
+
 - fix: preserve textarea content and status area on thinking state change
 - fix: extract proper content summary for direct display tools
 - fix: prevent raw JSON from rendering for direct display tools
@@ -91,6 +104,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ## [1.0.4] - 2026-02-03
 
 ### Changed
+
 - fix: make disabled sidebar tab properly inert and V12 compatibility
 - style: refine Discord link appearance in settings
 - fix: add Discord link to Foundry settings config, remove dead code
@@ -103,11 +117,13 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ## [1.0.3] - 2026-01-31
 
 ### Changed
+
 - fix: restore system-agnostic CSS for Carolingian UX compatibility
 
 ## [1.0.2] - 2026-01-31
 
 ### Changed
+
 - ci: switch to manual workflow_dispatch for releases
 - docs: add CONTRIBUTING.md with commit conventions
 - fix: correct content/display pattern in list_documents tool
@@ -135,9 +151,11 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - fix: prevent context overflow from large tool outputs
 - fix: remove oneOf from execute_macro schema for Anthropic compatibility
 - feat: auto-update CHANGELOG.md on release
+
 ## [1.0.0] - 2026-01-12
 
 ### Added
+
 - Initial public release of Simulacrum: AI Campaign Copilot
 - Natural language document management (create, read, update, delete)
 - Multi-provider AI support (OpenAI, Google Gemini, Anthropic, and OpenAI-compatible APIs)


### PR DESCRIPTION
## Summary
- add the 1.1.0 changelog entry for Foundry v14 support and unreleased fixes
- update the release workflow to read a pre-merged changelog entry instead of pushing directly to main
- keep tag creation, GitHub release asset creation, Foundry VTT publish, and Discord announcement in the release workflow

## Empirical Verification (UTRs)
- `git diff --check` -> pass
- `npx prettier --check CHANGELOG.md .github/workflows/create-release.yml` -> pass
- workflow YAML parse via `node -e "const fs=require('fs'); const yaml=require('js-yaml'); yaml.load(fs.readFileSync('.github/workflows/create-release.yml','utf8')); console.log('yaml ok')"` -> pass
- local changelog extraction for `1.1.0` produced the expected release body
- forbidden direct-push patterns `git push origin main`, `git add CHANGELOG`, `git commit.*CHANGELOG` -> no matches