### PR TITLE
feat(release): auto-generate changelog and support custom release title/description

### DIFF
--- a/.github/workflows/create-release.yml
+++ b/.github/workflows/create-release.yml
@@ -10,6 +10,14 @@ name: Create Release
         description: 'Version to release (e.g., 1.0.2)'
         required: true
         type: string
+      release_title:
+        description: 'Release title (default: v<version>)'
+        required: false
+        type: string
+      release_description:
+        description: 'Release description/shoutbox (prepended to changelog)'
+        required: false
+        type: string
 
 env:
   MODULE_ID: simulacrum
@@ -101,28 +109,71 @@ jobs:
           cd ..
           mv module.json.release module.json
 
-      - name: Verify changelog entry exists
-        id: changelog
+      - name: Generate changelog from commits
         run: |
           VERSION=${{ steps.version.outputs.version }}
-          if ! grep -q "^## \[${VERSION}\]" CHANGELOG.md; then
-            echo "::error::CHANGELOG.md is missing entry for version ${VERSION}"
-            echo "Expected heading: ## [${VERSION}]"
-            exit 1
+          LAST_TAG=$(git tag --list 'v*' --sort=-version:refname | grep -v "$VERSION" | head -1 | sed 's/^v//')
+          if [ -z "$LAST_TAG" ]; then
+            LAST_TAG=$(git rev-list --max-parents=0 HEAD)
           fi
-          echo "Changelog entry for ${VERSION} found"
+          echo "Generating changelog for $VERSION (since $LAST_TAG)"
+          node -e '
+            const { execSync } = require("child_process");
+            const fs = require("fs");
+            const version = "${VERSION}";
+            const lastTag = "${LAST_TAG}";
+            const log = execSync(`git log --pretty=format:"%s" ${lastTag}..HEAD`, { encoding: "utf-8" });
+            const commits = log.split("\n").filter(l => l.length > 0);
+            const sections = {};
+            const types = {
+              feat: "Features", fix: "Bug Fixes", refactor: "Refactoring",
+              perf: "Performance", docs: "Documentation", ci: "CI/CD",
+              build: "Build", chore: "Chores", test: "Testing", style: "Styles",
+            };
+            for (const c of commits) {
+              const m = c.match(/^(feat|fix|refactor|perf|docs|ci|build|chore|test|style)(\(.*?\))?:\s*(.*)/);
+              const type = m ? m[1] : "other";
+              const scope = m ? (m[2] || "") : "";
+              const msg = m ? m[3] : c;
+              const section = sections[type] || [];
+              section.push(scope ? `${scope} ${msg}` : msg);
+              sections[type] = section;
+            }
+            const order = ["feat", "fix", "refactor", "perf", "docs", "ci", "build", "chore", "test", "style", "other"];
+            const date = new Date().toISOString().slice(0, 10);
+            let entry = `## [${version}] - ${date}\n`;
+            for (const type of order) {
+              if (!sections[type]) continue;
+              entry += `\n### ${types[type] || "Other"}\n\n`;
+              for (const msg of sections[type]) entry += `- ${msg}\n`;
+            }
+            entry += "\n";
+            const ch = fs.readFileSync("CHANGELOG.md", "utf-8");
+            const firstVer = ch.indexOf("\n## [");
+            const insert = firstVer > 0 ? firstVer : ch.indexOf("## [");
+            const header = ch.slice(0, insert);
+            const rest = ch.slice(insert);
+            fs.writeFileSync("CHANGELOG.md", header + entry + rest);
+            console.log("Inserted changelog entry:\n" + entry.trim());
+          '
+          echo "version=${{ steps.version.outputs.version }}" >> $GITHUB_ENV
+          TITLE="${{ inputs.release_title }}"
+          if [ -z "$TITLE" ]; then
+            TITLE="v${{ steps.version.outputs.version }}"
+          fi
+          echo "RELEASE_TITLE=$TITLE" >> $GITHUB_ENV
 
-      - name: Extract changelog body for release
+      - name: Prepare release body
         run: |
           VERSION=${{ steps.version.outputs.version }}
-          # Extract lines after the version heading until the next heading or end of file
           awk "/^## \[${VERSION}\]/{found=1; next} /^## \[[0-9]/{exit} found{print}" CHANGELOG.md > changelog.txt
-          if [ ! -s changelog.txt ]; then
-            echo "::error::Changelog body for ${VERSION} is empty"
-            exit 1
+          if [ -n "${{ inputs.release_description }}" ]; then
+            { printf '%s\n\n' "${{ inputs.release_description }}"; cat changelog.txt; } > release_body.md
+          else
+            cp changelog.txt release_body.md
           fi
-          echo "Extracted changelog body:"
-          cat changelog.txt
+          echo "Release body:"
+          cat release_body.md
 
       - name: Get release bot user id
         id: bot-user
@@ -138,8 +189,8 @@ jobs:
           git config user.name "${{ steps.release-token.outputs.app-slug }}[bot]"
           git config user.email "${{ steps.bot-user.outputs.user-id }}+${{ steps.release-token.outputs.app-slug }}[bot]@users.noreply.github.com"
 
-          git add CHANGELOG.md
-          git commit -m "docs(release): update generated changelog for ${VERSION} [skip ci]" || echo "No changes to commit"
+          git add CHANGELOG.md module.json
+          git commit -m "docs(release): update changelog and module.json for ${VERSION} [skip ci]" || echo "No changes to commit"
 
           git tag -a "${VERSION}" -m "Release ${VERSION}"
           git push origin main
@@ -149,8 +200,8 @@ jobs:
         uses: softprops/action-gh-release@v1
         with:
           tag_name: ${{ steps.version.outputs.version }}
-          name: 'v${{ steps.version.outputs.version }}'
-          body_path: changelog.txt
+          name: ${{ env.RELEASE_TITLE }}
+          body_path: release_body.md
           files: |
             module.json
             ${{ env.MODULE_ID }}.zip


### PR DESCRIPTION
## Summary

- **Auto-generate changelog** from commits since last tag, grouped by conventional commit type (feat, fix, refactor, etc.) — no manual changelog editing required
- **Custom release title** via `-f release_title="..."` input (defaults to `v<version>`)
- **Custom release description** via `-f release_description="..."` input, prepended to the changelog in the GitHub Release body
- Commit step now includes `module.json` alongside `CHANGELOG.md`

## Usage

```bash
gh workflow run create-release.yml -f version=1.1.0 \
  -f release_title="Simulacrum 1.1.0: Foundry v14 Ready" \
  -f release_description="Major release adding full Foundry v14 support..."
```

Or just `-f version=1.1.0` for defaults.