### PR TITLE
docs: seed [Unreleased] changelog entry for 1.1.0

### DIFF
--- a/.github/workflows/update-changelog.yml
+++ b/.github/workflows/update-changelog.yml
@@ -101,7 +101,7 @@ jobs:
           '
 
       - name: Push changelog update via REST API
-     if: steps.generate.outcome == 'success' && github.event_name == 'push'
+        if: steps.generate.outcome == 'success' && github.event_name == 'push'
         run: |
           if ! git diff --quiet CHANGELOG.md; then
             BOT_NAME="${{ steps.release-token.outputs.app-slug }}[bot]"

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,21 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
 
+## [Unreleased] - 2026-06-13
+
+### Features
+
+- compat: add Foundry v14 support by fixing sidebar rendering regression
+- ci: add Copilot code review workflow with PR gating and testing requirements
+
+### Bug Fixes
+
+- ui: prevent race condition cascade on message cancellation
+- core: fix context compaction overflow and context limit honoring (Fixes #150)
+- core: ensure outgoing tool call arguments are valid JSON (Fixes #145)
+- index: persist hasEverIndexed flag to unblock search_assets on reload (Fixes #126)
+
+
 ## [1.0.9] - 2026-03-18
 
 ### Changed


### PR DESCRIPTION
Manual seed of the [Unreleased] section with commits since 1.0.9. Required because the post-merge changelog workflow had a YAML syntax error that prevented it from running.