### PR TITLE
fix(ci): use Contents API for workflow file updates

### DIFF
--- a/.github/workflows/create-release.yml
+++ b/.github/workflows/create-release.yml
@@ -1,5 +1,5 @@
 # FoundryVTT Module Release Workflow
-# Manual trigger only - run with: gh workflow run release.yml -f version=1.0.2
+# Manual trigger only - run with: gh workflow run create-release.yml -f version=1.0.2
 
 name: Create Release
 
@@ -110,27 +110,35 @@ jobs:
           mv module.json.release module.json
 
       - name: Version changelog entry
+        env:
+          INPUT_RELEASE_TITLE: ${{ inputs.release_title }}
         run: |
           VERSION=${{ steps.version.outputs.version }}
           if grep -q "^## \[Unreleased\]" CHANGELOG.md; then
-            sed -i "s/^## \[Unreleased\] - .*$/## [${VERSION}] - $(date -u +%Y-%m-%d)/" CHANGELOG.md
+            sed -i "s/^## \[Unreleased\].*$/## [${VERSION}] - $(date -u +%Y-%m-%d)/" CHANGELOG.md
             echo "Versioned [Unreleased] entry to [${VERSION}]"
           elif ! grep -q "^## \[${VERSION}\]" CHANGELOG.md; then
             echo "::error::CHANGELOG.md is missing both [Unreleased] and [${VERSION}] entry"
             exit 1
           fi
-          TITLE="${{ inputs.release_title }}"
+          TITLE="$INPUT_RELEASE_TITLE"
           if [ -z "$TITLE" ]; then
-            TITLE="v${{ steps.version.outputs.version }}"
+            TITLE="v${VERSION}"
           fi
-          echo "RELEASE_TITLE=$TITLE" >> $GITHUB_ENV
+          echo "RELEASE_TITLE=$TITLE" >> "$GITHUB_ENV"
 
       - name: Prepare release body
+        env:
+          RELEASE_DESCRIPTION: ${{ inputs.release_description }}
         run: |
           VERSION=${{ steps.version.outputs.version }}
-          awk "/^## \[${VERSION}\]/{found=1; next} /^## \[[0-9]/{exit} found{print}" CHANGELOG.md > changelog.txt
-          if [ -n "${{ inputs.release_description }}" ]; then
-            { printf '%s\n\n' "${{ inputs.release_description }}"; cat changelog.txt; } > release_body.md
+          awk -v version="$VERSION" '
+            $0 == "## [" version "]" || index($0, "## [" version "] - ") == 1 { found=1; next }
+            found && /^## \[/ { exit }
+            found { print }
+          ' CHANGELOG.md > changelog.txt
+          if [ -n "$RELEASE_DESCRIPTION" ]; then
+            { printf '%s\n\n' "$RELEASE_DESCRIPTION"; cat changelog.txt; } > release_body.md
           else
             cp changelog.txt release_body.md
           fi
@@ -149,26 +157,62 @@ jobs:
           VERSION=${{ steps.version.outputs.version }}
           BOT_NAME="${{ steps.release-token.outputs.app-slug }}[bot]"
           BOT_EMAIL="${{ steps.bot-user.outputs.user-id }}+${{ steps.release-token.outputs.app-slug }}[bot]@users.noreply.github.com"
+          COMMIT_SHA=$(git rev-parse HEAD)
 
-          git config user.name "$BOT_NAME"
-          git config user.email "$BOT_EMAIL"
+          update_file() {
+            local path="$1"
+            local message="$2"
 
-          git add CHANGELOG.md module.json
-          if ! git diff --cached --quiet; then
-            TREE_SHA=$(git write-tree)
-            PARENT_SHA=$(git rev-parse main)
-            gh api /repos/${{ github.repository }}/git/commits \
-              --method POST \
-              --field "sha=$PARENT_SHA" \
-              --field "tree=$TREE_SHA" \
-              --field "message=docs(release): changelog and module.json for ${VERSION} [skip ci]" \
-              --jq .sha
+            FILE_SHA=$(gh api "/repos/${{ github.repository }}/contents/${path}" \
+              --field ref=main \
+              --jq .sha)
+
+            jq -n \
+              --arg message "$message" \
+              --arg content "$(base64 -w 0 "$path")" \
+              --arg sha "$FILE_SHA" \
+              --arg branch "main" \
+              --arg name "$BOT_NAME" \
+              --arg email "$BOT_EMAIL" \
+              '{
+                message: $message,
+                content: $content,
+                sha: $sha,
+                branch: $branch,
+                committer: {name: $name, email: $email},
+                author: {name: $name, email: $email}
+              }' > "/tmp/update-${path//\//-}.json"
+
+            COMMIT_SHA=$(gh api "/repos/${{ github.repository }}/contents/${path}" \
+              --method PUT \
+              --input "/tmp/update-${path//\//-}.json" \
+              --jq .commit.sha)
+          }
+
+          if ! git diff --quiet CHANGELOG.md; then
+            update_file "CHANGELOG.md" "docs(release): changelog for ${VERSION} [skip ci]"
           else
-            echo "No changes to commit"
+            echo "No CHANGELOG.md changes to commit"
           fi
 
-          git tag -a "${VERSION}" -m "Release ${VERSION}"
-          git push origin "${VERSION}"
+          if ! git diff --quiet module.json; then
+            update_file "module.json" "docs(release): module.json for ${VERSION} [skip ci]"
+          else
+            echo "No module.json changes to commit"
+          fi
+
+          TAG_SHA=$(gh api /repos/${{ github.repository }}/git/tags \
+            --method POST \
+            --field "tag=${VERSION}" \
+            --field "message=Release ${VERSION}" \
+            --field "object=${COMMIT_SHA}" \
+            --field "type=commit" \
+            --jq .sha)
+
+          gh api /repos/${{ github.repository }}/git/refs \
+            --method POST \
+            --field "ref=refs/tags/${VERSION}" \
+            --field "sha=${TAG_SHA}"
         env:
           GH_TOKEN: ${{ steps.release-token.outputs.token }}
 

--- a/.github/workflows/update-changelog.yml
+++ b/.github/workflows/update-changelog.yml
@@ -13,7 +13,9 @@ jobs:
     runs-on: ubuntu-latest
     permissions:
       contents: write
-    if: "!startsWith(github.event.head_commit.message, 'docs(release):')"
+    if: >-
+      !startsWith(github.event.head_commit.message, 'docs(release):') &&
+      !startsWith(github.event.head_commit.message, 'docs: update unreleased changelog')
     steps:
       - name: Generate release bot token
         id: release-token
@@ -42,18 +44,20 @@ jobs:
         id: generate
         continue-on-error: true
         run: |
-          LAST_TAG=$(git tag --list 'v*' --sort=-version:refname | head -1 | sed 's/^v//')
+          LAST_TAG=$(git tag --list --sort=-version:refname | grep -E '^[v]?[0-9]+\.[0-9]+\.[0-9]+$' | head -1 || true)
           if [ -z "$LAST_TAG" ]; then
-            LAST_TAG=$(git rev-list --max-parents=0 HEAD)
+            LAST_REF=$(git rev-list --max-parents=0 HEAD)
+          else
+            LAST_REF="$LAST_TAG"
           fi
-          export LAST_TAG
-          echo "Collecting commits since $LAST_TAG"
+          export LAST_REF
+          echo "Collecting commits since $LAST_REF"
 
           node -e '
             const { execSync } = require("child_process");
             const fs = require("fs");
-            const lastTag = process.env.LAST_TAG;
-            const log = execSync(`git log --pretty=format:"%s" ${lastTag}..HEAD`, { encoding: "utf-8" });
+            const lastRef = process.env.LAST_REF;
+            const log = execSync(`git log --pretty=format:"%s" ${lastRef}..HEAD`, { encoding: "utf-8" });
             const commits = log.split("\n").filter(l => l.length > 0 && !l.includes("docs(release):") && !l.includes("docs: update unreleased changelog"));
             if (commits.length === 0) {
               console.log("No relevant commits since last tag");
@@ -86,37 +90,51 @@ jobs:
             const ch = fs.readFileSync("CHANGELOG.md", "utf-8");
             const unreleasedMarker = "## [Unreleased]";
             const existing = ch.indexOf(unreleasedMarker);
-            if (existing > 0) {
-              const nextHeader = ch.indexOf("\n## [", existing);
-              const newContent = nextHeader > 0 ? ch.slice(0, existing) + entry + ch.slice(nextHeader) : ch.slice(0, existing) + entry;
+            if (existing >= 0) {
+              const nextHeader = ch.indexOf("\n## [", existing + 1);
+              const newContent = nextHeader > 0 ? ch.slice(0, existing) + entry + ch.slice(nextHeader + 1) : ch.slice(0, existing) + entry;
               fs.writeFileSync("CHANGELOG.md", newContent);
             } else {
-              const firstVer = ch.indexOf("\n## [");
-              const insert = firstVer > 0 ? firstVer : ch.indexOf("## [");
-              const header = ch.slice(0, insert);
-              const rest = ch.slice(insert);
-              fs.writeFileSync("CHANGELOG.md", header + entry + rest);
+              const firstVersionHeader = ch.indexOf("\n## [");
+              if (firstVersionHeader < 0) {
+                throw new Error("CHANGELOG.md has no version header insertion point");
+              }
+              fs.writeFileSync("CHANGELOG.md", ch.slice(0, firstVersionHeader + 1) + entry + ch.slice(firstVersionHeader + 1));
             }
             console.log("Updated unreleased changelog:\n" + entry.trim());
           '
 
-      - name: Push changelog update via REST API
+      - name: Push changelog update via Contents API
         if: steps.generate.outcome == 'success' && github.event_name == 'push'
         run: |
           if ! git diff --quiet CHANGELOG.md; then
             BOT_NAME="${{ steps.release-token.outputs.app-slug }}[bot]"
             BOT_EMAIL="${{ steps.bot-user.outputs.user-id }}+${{ steps.release-token.outputs.app-slug }}[bot]@users.noreply.github.com"
-            git config user.name "$BOT_NAME"
-            git config user.email "$BOT_EMAIL"
-            git add CHANGELOG.md
-            TREE_SHA=$(git write-tree)
-            PARENT_SHA=$(git rev-parse main)
-            gh api /repos/${{ github.repository }}/git/commits \
-              --method POST \
-              --field "sha=$PARENT_SHA" \
-              --field "tree=$TREE_SHA" \
-              --field 'message="docs: update unreleased changelog [skip ci]"' \
-              --jq .sha
+
+            FILE_SHA=$(gh api /repos/${{ github.repository }}/contents/CHANGELOG.md \
+              --field ref=main \
+              --jq .sha)
+
+            jq -n \
+              --arg message "docs: update unreleased changelog [skip ci]" \
+              --arg content "$(base64 -w 0 CHANGELOG.md)" \
+              --arg sha "$FILE_SHA" \
+              --arg branch "main" \
+              --arg name "$BOT_NAME" \
+              --arg email "$BOT_EMAIL" \
+              '{
+                message: $message,
+                content: $content,
+                sha: $sha,
+                branch: $branch,
+                committer: {name: $name, email: $email},
+                author: {name: $name, email: $email}
+              }' > /tmp/update-changelog.json
+
+            gh api /repos/${{ github.repository }}/contents/CHANGELOG.md \
+              --method PUT \
+              --input /tmp/update-changelog.json \
+              --jq .commit.sha
           else
             echo "No changes to push"
           fi


### PR DESCRIPTION
## Summary

- Update the changelog workflow to write CHANGELOG.md through the Repository Contents API.
- Update the release workflow to write CHANGELOG.md and module.json through the Repository Contents API.
- Create the release tag against the final commit returned by those file updates.
- Fix last-tag detection to accept both 1.2.3 and v1.2.3 tags.

## Validation

- Parsed both workflow files with PyYAML.
- Ran bash syntax checks against every run block after replacing GitHub expression placeholders.
- Fetched the branch copies of both workflow files after pushing the changes.