### PR TITLE
fix(ci): harden workflow API writes

### DIFF
--- a/.github/workflows/create-release.yml
+++ b/.github/workflows/create-release.yml
@@ -109,54 +109,16 @@ jobs:
           cd ..
           mv module.json.release module.json
 
-      - name: Generate changelog from commits
+      - name: Version changelog entry
         run: |
           VERSION=${{ steps.version.outputs.version }}
-          LAST_TAG=$(git tag --list 'v*' --sort=-version:refname | grep -v "$VERSION" | head -1 | sed 's/^v//')
-          if [ -z "$LAST_TAG" ]; then
-            LAST_TAG=$(git rev-list --max-parents=0 HEAD)
+          if grep -q "^## \[Unreleased\]" CHANGELOG.md; then
+            sed -i "s/^## \[Unreleased\] - .*$/## [${VERSION}] - $(date -u +%Y-%m-%d)/" CHANGELOG.md
+            echo "Versioned [Unreleased] entry to [${VERSION}]"
+          elif ! grep -q "^## \[${VERSION}\]" CHANGELOG.md; then
+            echo "::error::CHANGELOG.md is missing both [Unreleased] and [${VERSION}] entry"
+            exit 1
           fi
-          echo "Generating changelog for $VERSION (since $LAST_TAG)"
-          node -e '
-            const { execSync } = require("child_process");
-            const fs = require("fs");
-            const version = "${VERSION}";
-            const lastTag = "${LAST_TAG}";
-            const log = execSync(`git log --pretty=format:"%s" ${lastTag}..HEAD`, { encoding: "utf-8" });
-            const commits = log.split("\n").filter(l => l.length > 0);
-            const sections = {};
-            const types = {
-              feat: "Features", fix: "Bug Fixes", refactor: "Refactoring",
-              perf: "Performance", docs: "Documentation", ci: "CI/CD",
-              build: "Build", chore: "Chores", test: "Testing", style: "Styles",
-            };
-            for (const c of commits) {
-              const m = c.match(/^(feat|fix|refactor|perf|docs|ci|build|chore|test|style)(\(.*?\))?:\s*(.*)/);
-              const type = m ? m[1] : "other";
-              const scope = m ? (m[2] || "") : "";
-              const msg = m ? m[3] : c;
-              const section = sections[type] || [];
-              section.push(scope ? `${scope} ${msg}` : msg);
-              sections[type] = section;
-            }
-            const order = ["feat", "fix", "refactor", "perf", "docs", "ci", "build", "chore", "test", "style", "other"];
-            const date = new Date().toISOString().slice(0, 10);
-            let entry = `## [${version}] - ${date}\n`;
-            for (const type of order) {
-              if (!sections[type]) continue;
-              entry += `\n### ${types[type] || "Other"}\n\n`;
-              for (const msg of sections[type]) entry += `- ${msg}\n`;
-            }
-            entry += "\n";
-            const ch = fs.readFileSync("CHANGELOG.md", "utf-8");
-            const firstVer = ch.indexOf("\n## [");
-            const insert = firstVer > 0 ? firstVer : ch.indexOf("## [");
-            const header = ch.slice(0, insert);
-            const rest = ch.slice(insert);
-            fs.writeFileSync("CHANGELOG.md", header + entry + rest);
-            console.log("Inserted changelog entry:\n" + entry.trim());
-          '
-          echo "version=${{ steps.version.outputs.version }}" >> $GITHUB_ENV
           TITLE="${{ inputs.release_title }}"
           if [ -z "$TITLE" ]; then
             TITLE="v${{ steps.version.outputs.version }}"
@@ -182,19 +144,33 @@ jobs:
         env:
           GH_TOKEN: ${{ steps.release-token.outputs.token }}
 
-      - name: Commit CHANGELOG.md and create tag
+      - name: Commit release updates and create tag
         run: |
           VERSION=${{ steps.version.outputs.version }}
+          BOT_NAME="${{ steps.release-token.outputs.app-slug }}[bot]"
+          BOT_EMAIL="${{ steps.bot-user.outputs.user-id }}+${{ steps.release-token.outputs.app-slug }}[bot]@users.noreply.github.com"
 
-          git config user.name "${{ steps.release-token.outputs.app-slug }}[bot]"
-          git config user.email "${{ steps.bot-user.outputs.user-id }}+${{ steps.release-token.outputs.app-slug }}[bot]@users.noreply.github.com"
+          git config user.name "$BOT_NAME"
+          git config user.email "$BOT_EMAIL"
 
           git add CHANGELOG.md module.json
-          git commit -m "docs(release): update changelog and module.json for ${VERSION} [skip ci]" || echo "No changes to commit"
+          if ! git diff --cached --quiet; then
+            TREE_SHA=$(git write-tree)
+            PARENT_SHA=$(git rev-parse main)
+            gh api /repos/${{ github.repository }}/git/commits \
+              --method POST \
+              --field "sha=$PARENT_SHA" \
+              --field "tree=$TREE_SHA" \
+              --field "message=docs(release): changelog and module.json for ${VERSION} [skip ci]" \
+              --jq .sha
+          else
+            echo "No changes to commit"
+          fi
 
           git tag -a "${VERSION}" -m "Release ${VERSION}"
-          git push origin main
           git push origin "${VERSION}"
+        env:
+          GH_TOKEN: ${{ steps.release-token.outputs.token }}
 
       - name: Create GitHub Release
         uses: softprops/action-gh-release@v1

--- a/.github/workflows/create-release.yml
+++ b/.github/workflows/create-release.yml
@@ -10,6 +10,14 @@ name: Create Release
         description: 'Version to release (e.g., 1.0.2)'
         required: true
         type: string
+      release_title:
+        description: 'Release title (default: v<version>)'
+        required: false
+        type: string
+      release_description:
+        description: 'Release description/shoutbox (prepended to changelog)'
+        required: false
+        type: string
 
 env:
   MODULE_ID: simulacrum
@@ -101,28 +109,71 @@ jobs:
           cd ..
           mv module.json.release module.json
 
-      - name: Verify changelog entry exists
-        id: changelog
+      - name: Generate changelog from commits
         run: |
           VERSION=${{ steps.version.outputs.version }}
-          if ! grep -q "^## \[${VERSION}\]" CHANGELOG.md; then
-            echo "::error::CHANGELOG.md is missing entry for version ${VERSION}"
-            echo "Expected heading: ## [${VERSION}]"
-            exit 1
+          LAST_TAG=$(git tag --list 'v*' --sort=-version:refname | grep -v "$VERSION" | head -1 | sed 's/^v//')
+          if [ -z "$LAST_TAG" ]; then
+            LAST_TAG=$(git rev-list --max-parents=0 HEAD)
           fi
-          echo "Changelog entry for ${VERSION} found"
+          echo "Generating changelog for $VERSION (since $LAST_TAG)"
+          node -e '
+            const { execSync } = require("child_process");
+            const fs = require("fs");
+            const version = "${VERSION}";
+            const lastTag = "${LAST_TAG}";
+            const log = execSync(`git log --pretty=format:"%s" ${lastTag}..HEAD`, { encoding: "utf-8" });
+            const commits = log.split("\n").filter(l => l.length > 0);
+            const sections = {};
+            const types = {
+              feat: "Features", fix: "Bug Fixes", refactor: "Refactoring",
+              perf: "Performance", docs: "Documentation", ci: "CI/CD",
+              build: "Build", chore: "Chores", test: "Testing", style: "Styles",
+            };
+            for (const c of commits) {
+              const m = c.match(/^(feat|fix|refactor|perf|docs|ci|build|chore|test|style)(\(.*?\))?:\s*(.*)/);
+              const type = m ? m[1] : "other";
+              const scope = m ? (m[2] || "") : "";
+              const msg = m ? m[3] : c;
+              const section = sections[type] || [];
+              section.push(scope ? `${scope} ${msg}` : msg);
+              sections[type] = section;
+            }
+            const order = ["feat", "fix", "refactor", "perf", "docs", "ci", "build", "chore", "test", "style", "other"];
+            const date = new Date().toISOString().slice(0, 10);
+            let entry = `## [${version}] - ${date}\n`;
+            for (const type of order) {
+              if (!sections[type]) continue;
+              entry += `\n### ${types[type] || "Other"}\n\n`;
+              for (const msg of sections[type]) entry += `- ${msg}\n`;
+            }
+            entry += "\n";
+            const ch = fs.readFileSync("CHANGELOG.md", "utf-8");
+            const firstVer = ch.indexOf("\n## [");
+            const insert = firstVer > 0 ? firstVer : ch.indexOf("## [");
+            const header = ch.slice(0, insert);
+            const rest = ch.slice(insert);
+            fs.writeFileSync("CHANGELOG.md", header + entry + rest);
+            console.log("Inserted changelog entry:\n" + entry.trim());
+          '
+          echo "version=${{ steps.version.outputs.version }}" >> $GITHUB_ENV
+          TITLE="${{ inputs.release_title }}"
+          if [ -z "$TITLE" ]; then
+            TITLE="v${{ steps.version.outputs.version }}"
+          fi
+          echo "RELEASE_TITLE=$TITLE" >> $GITHUB_ENV
 
-      - name: Extract changelog body for release
+      - name: Prepare release body
         run: |
           VERSION=${{ steps.version.outputs.version }}
-          # Extract lines after the version heading until the next heading or end of file
           awk "/^## \[${VERSION}\]/{found=1; next} /^## \[[0-9]/{exit} found{print}" CHANGELOG.md > changelog.txt
-          if [ ! -s changelog.txt ]; then
-            echo "::error::Changelog body for ${VERSION} is empty"
-            exit 1
+          if [ -n "${{ inputs.release_description }}" ]; then
+            { printf '%s\n\n' "${{ inputs.release_description }}"; cat changelog.txt; } > release_body.md
+          else
+            cp changelog.txt release_body.md
           fi
-          echo "Extracted changelog body:"
-          cat changelog.txt
+          echo "Release body:"
+          cat release_body.md
 
       - name: Get release bot user id
         id: bot-user
@@ -138,8 +189,8 @@ jobs:
           git config user.name "${{ steps.release-token.outputs.app-slug }}[bot]"
           git config user.email "${{ steps.bot-user.outputs.user-id }}+${{ steps.release-token.outputs.app-slug }}[bot]@users.noreply.github.com"
 
-          git add CHANGELOG.md
-          git commit -m "docs(release): update generated changelog for ${VERSION} [skip ci]" || echo "No changes to commit"
+          git add CHANGELOG.md module.json
+          git commit -m "docs(release): update changelog and module.json for ${VERSION} [skip ci]" || echo "No changes to commit"
 
           git tag -a "${VERSION}" -m "Release ${VERSION}"
           git push origin main
@@ -149,8 +200,8 @@ jobs:
         uses: softprops/action-gh-release@v1
         with:
           tag_name: ${{ steps.version.outputs.version }}
-          name: 'v${{ steps.version.outputs.version }}'
-          body_path: changelog.txt
+          name: ${{ env.RELEASE_TITLE }}
+          body_path: release_body.md
           files: |
             module.json
             ${{ env.MODULE_ID }}.zip

--- a/.github/workflows/create-release.yml
+++ b/.github/workflows/create-release.yml
@@ -3,19 +3,19 @@
 
 name: Create Release
 
-'on':
+"on":
   workflow_dispatch:
     inputs:
       version:
-        description: 'Version to release (e.g., 1.0.2)'
+        description: "Version to release (e.g., 1.0.2)"
         required: true
         type: string
       release_title:
-        description: 'Release title (default: v<version>)'
+        description: "Release title (default: v<version>)"
         required: false
         type: string
       release_description:
-        description: 'Release description/shoutbox (prepended to changelog)'
+        description: "Release description/shoutbox (prepended to changelog)"
         required: false
         type: string
 
@@ -48,8 +48,8 @@ jobs:
       - name: Setup Node.js
         uses: actions/setup-node@v4
         with:
-          node-version: '20'
-          cache: 'npm'
+          node-version: "20"
+          cache: "npm"
 
       - name: Install dependencies
         run: npm ci
@@ -157,62 +157,60 @@ jobs:
           VERSION=${{ steps.version.outputs.version }}
           BOT_NAME="${{ steps.release-token.outputs.app-slug }}[bot]"
           BOT_EMAIL="${{ steps.bot-user.outputs.user-id }}+${{ steps.release-token.outputs.app-slug }}[bot]@users.noreply.github.com"
-          COMMIT_SHA=$(git rev-parse HEAD)
 
-          update_file() {
-            local path="$1"
-            local message="$2"
-
-            FILE_SHA=$(gh api "/repos/${{ github.repository }}/contents/${path}" \
-              --field ref=main \
-              --jq .sha)
-
-            jq -n \
-              --arg message "$message" \
-              --arg content "$(base64 -w 0 "$path")" \
-              --arg sha "$FILE_SHA" \
-              --arg branch "main" \
+          if ! git diff --quiet CHANGELOG.md module.json; then
+            BASE_SHA=$(git rev-parse HEAD)
+            BASE_TREE_SHA=$(gh api "/repos/${{ github.repository }}/git/commits/${BASE_SHA}" --jq .tree.sha)
+            TREE_SHA=$(jq -n \
+              --arg base_tree "$BASE_TREE_SHA" \
+              --rawfile changelog CHANGELOG.md \
+              --rawfile module module.json \
+              '{
+                base_tree: $base_tree,
+                tree: [
+                  {path: "CHANGELOG.md", mode: "100644", type: "blob", content: $changelog},
+                  {path: "module.json", mode: "100644", type: "blob", content: $module}
+                ]
+              }' | gh api "/repos/${{ github.repository }}/git/trees" --method POST --input - --jq .sha)
+            COMMIT_SHA=$(jq -n \
+              --arg message "docs(release): changelog and module.json for ${VERSION} [skip ci]" \
+              --arg tree "$TREE_SHA" \
+              --arg parent "$BASE_SHA" \
               --arg name "$BOT_NAME" \
               --arg email "$BOT_EMAIL" \
               '{
                 message: $message,
-                content: $content,
-                sha: $sha,
-                branch: $branch,
-                committer: {name: $name, email: $email},
-                author: {name: $name, email: $email}
-              }' > "/tmp/update-${path//\//-}.json"
-
-            COMMIT_SHA=$(gh api "/repos/${{ github.repository }}/contents/${path}" \
-              --method PUT \
-              --input "/tmp/update-${path//\//-}.json" \
-              --jq .commit.sha)
-          }
-
-          if ! git diff --quiet CHANGELOG.md; then
-            update_file "CHANGELOG.md" "docs(release): changelog for ${VERSION} [skip ci]"
+                tree: $tree,
+                parents: [$parent],
+                author: {name: $name, email: $email},
+                committer: {name: $name, email: $email}
+              }' | gh api "/repos/${{ github.repository }}/git/commits" --method POST --input - --jq .sha)
+            gh api "/repos/${{ github.repository }}/git/refs/heads/main" \
+              --method PATCH \
+              --field "sha=$COMMIT_SHA" \
+              --field "force=false"
           else
-            echo "No CHANGELOG.md changes to commit"
+            echo "No changes to commit"
+            COMMIT_SHA=$(git rev-parse HEAD)
           fi
 
-          if ! git diff --quiet module.json; then
-            update_file "module.json" "docs(release): module.json for ${VERSION} [skip ci]"
-          else
-            echo "No module.json changes to commit"
-          fi
-
-          TAG_SHA=$(gh api /repos/${{ github.repository }}/git/tags \
-            --method POST \
-            --field "tag=${VERSION}" \
-            --field "message=Release ${VERSION}" \
-            --field "object=${COMMIT_SHA}" \
-            --field "type=commit" \
-            --jq .sha)
-
-          gh api /repos/${{ github.repository }}/git/refs \
+          TAG_SHA=$(jq -n \
+            --arg tag "$VERSION" \
+            --arg message "Release ${VERSION}" \
+            --arg object "$COMMIT_SHA" \
+            --arg name "$BOT_NAME" \
+            --arg email "$BOT_EMAIL" \
+            '{
+              tag: $tag,
+              message: $message,
+              object: $object,
+              type: "commit",
+              tagger: {name: $name, email: $email}
+            }' | gh api "/repos/${{ github.repository }}/git/tags" --method POST --input - --jq .sha)
+          gh api "/repos/${{ github.repository }}/git/refs" \
             --method POST \
             --field "ref=refs/tags/${VERSION}" \
-            --field "sha=${TAG_SHA}"
+            --field "sha=$TAG_SHA"
         env:
           GH_TOKEN: ${{ steps.release-token.outputs.token }}
 

--- a/.github/workflows/create-release.yml
+++ b/.github/workflows/create-release.yml
@@ -3,7 +3,7 @@
 
 name: Create Release
 
-"on":
+'on':
   workflow_dispatch:
     inputs:
       version:
@@ -21,11 +21,21 @@ jobs:
       contents: write
 
     steps:
+      - name: Generate release bot token
+        id: release-token
+        uses: actions/create-github-app-token@v3
+        with:
+          client-id: ${{ vars.RELEASE_APP_CLIENT_ID }}
+          private-key: ${{ secrets.RELEASE_APP_PRIVATE_KEY }}
+          permission-contents: write
+
       - name: Checkout
         uses: actions/checkout@v4
         with:
           fetch-depth: 0
           ref: main
+          token: ${{ steps.release-token.outputs.token }}
+          persist-credentials: true
 
       - name: Setup Node.js
         uses: actions/setup-node@v4
@@ -91,45 +101,46 @@ jobs:
           cd ..
           mv module.json.release module.json
 
-      - name: Generate changelog
+      - name: Verify changelog entry exists
         id: changelog
         run: |
           VERSION=${{ steps.version.outputs.version }}
-          TODAY=$(date +%Y-%m-%d)
-          PREV_TAG=$(git describe --tags --abbrev=0 HEAD 2>/dev/null || echo "")
-          if [ -n "$PREV_TAG" ]; then
-            echo "Generating changelog from $PREV_TAG to HEAD"
-            COMMITS=$(git log --pretty=format:"- %s" $PREV_TAG..HEAD | grep -vE '^- (docs|ci|chore):')
-          else
-            echo "No previous tag found, including recent commits"
-            COMMITS=$(git log --pretty=format:"- %s" HEAD~10..HEAD 2>/dev/null || git log --pretty=format:"- %s" | grep -vE '^- (docs|ci|chore):')
+          if ! grep -q "^## \[${VERSION}\]" CHANGELOG.md; then
+            echo "::error::CHANGELOG.md is missing entry for version ${VERSION}"
+            echo "Expected heading: ## [${VERSION}]"
+            exit 1
           fi
-          # Ensure we have at least something for the changelog
-          if [ -z "$COMMITS" ]; then
-            COMMITS="- Maintenance release"
-          fi
-          echo "$COMMITS" > changelog.txt
-          cat > new_entry.txt << 'ENTRY_EOF'
-          ## [$VERSION] - $TODAY
+          echo "Changelog entry for ${VERSION} found"
 
-          ### Changed
-          ENTRY_EOF
-          sed -i "s/\$VERSION/$VERSION/g; s/\$TODAY/$TODAY/g" new_entry.txt
-          echo "$COMMITS" >> new_entry.txt
-          head -n 7 CHANGELOG.md > CHANGELOG.tmp
-          echo "" >> CHANGELOG.tmp
-          cat new_entry.txt >> CHANGELOG.tmp
-          tail -n +8 CHANGELOG.md >> CHANGELOG.tmp
-          mv CHANGELOG.tmp CHANGELOG.md
-          rm new_entry.txt
+      - name: Extract changelog body for release
+        run: |
+          VERSION=${{ steps.version.outputs.version }}
+          # Extract lines after the version heading until the next heading or end of file
+          awk "/^## \[${VERSION}\]/{found=1; next} /^## \[[0-9]/{exit} found{print}" CHANGELOG.md > changelog.txt
+          if [ ! -s changelog.txt ]; then
+            echo "::error::Changelog body for ${VERSION} is empty"
+            exit 1
+          fi
+          echo "Extracted changelog body:"
+          cat changelog.txt
+
+      - name: Get release bot user id
+        id: bot-user
+        run: |
+          echo "user-id=$(gh api "/users/${{ steps.release-token.outputs.app-slug }}[bot]" --jq .id)" >> "$GITHUB_OUTPUT"
+        env:
+          GH_TOKEN: ${{ steps.release-token.outputs.token }}
 
       - name: Commit CHANGELOG.md and create tag
         run: |
           VERSION=${{ steps.version.outputs.version }}
-          git config user.name "github-actions[bot]"
-          git config user.email "github-actions[bot]@users.noreply.github.com"
+
+          git config user.name "${{ steps.release-token.outputs.app-slug }}[bot]"
+          git config user.email "${{ steps.bot-user.outputs.user-id }}+${{ steps.release-token.outputs.app-slug }}[bot]@users.noreply.github.com"
+
           git add CHANGELOG.md
-          git commit -m "docs: update CHANGELOG.md for ${VERSION}" || echo "No changes to commit"
+          git commit -m "docs(release): update generated changelog for ${VERSION} [skip ci]" || echo "No changes to commit"
+
           git tag -a "${VERSION}" -m "Release ${VERSION}"
           git push origin main
           git push origin "${VERSION}"
@@ -138,14 +149,14 @@ jobs:
         uses: softprops/action-gh-release@v1
         with:
           tag_name: ${{ steps.version.outputs.version }}
-          name: "v${{ steps.version.outputs.version }}"
+          name: 'v${{ steps.version.outputs.version }}'
           body_path: changelog.txt
           files: |
             module.json
             ${{ env.MODULE_ID }}.zip
           fail_on_unmatched_files: true
         env:
-          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+          GITHUB_TOKEN: ${{ steps.release-token.outputs.token }}
 
       - name: Publish to Foundry VTT
         env:

--- a/.github/workflows/create-release.yml
+++ b/.github/workflows/create-release.yml
@@ -1,5 +1,5 @@
 # FoundryVTT Module Release Workflow
-# Manual trigger only - run with: gh workflow run release.yml -f version=1.0.2
+# Manual trigger only - run with: gh workflow run create-release.yml -f version=1.0.2
 
 name: Create Release
 
@@ -110,27 +110,35 @@ jobs:
           mv module.json.release module.json
 
       - name: Version changelog entry
+        env:
+          INPUT_RELEASE_TITLE: ${{ inputs.release_title }}
         run: |
           VERSION=${{ steps.version.outputs.version }}
           if grep -q "^## \[Unreleased\]" CHANGELOG.md; then
-            sed -i "s/^## \[Unreleased\] - .*$/## [${VERSION}] - $(date -u +%Y-%m-%d)/" CHANGELOG.md
+            sed -i "s/^## \[Unreleased\].*$/## [${VERSION}] - $(date -u +%Y-%m-%d)/" CHANGELOG.md
             echo "Versioned [Unreleased] entry to [${VERSION}]"
           elif ! grep -q "^## \[${VERSION}\]" CHANGELOG.md; then
             echo "::error::CHANGELOG.md is missing both [Unreleased] and [${VERSION}] entry"
             exit 1
           fi
-          TITLE="${{ inputs.release_title }}"
+          TITLE="$INPUT_RELEASE_TITLE"
           if [ -z "$TITLE" ]; then
-            TITLE="v${{ steps.version.outputs.version }}"
+            TITLE="v${VERSION}"
           fi
-          echo "RELEASE_TITLE=$TITLE" >> $GITHUB_ENV
+          echo "RELEASE_TITLE=$TITLE" >> "$GITHUB_ENV"
 
       - name: Prepare release body
+        env:
+          RELEASE_DESCRIPTION: ${{ inputs.release_description }}
         run: |
           VERSION=${{ steps.version.outputs.version }}
-          awk "/^## \[${VERSION}\]/{found=1; next} /^## \[[0-9]/{exit} found{print}" CHANGELOG.md > changelog.txt
-          if [ -n "${{ inputs.release_description }}" ]; then
-            { printf '%s\n\n' "${{ inputs.release_description }}"; cat changelog.txt; } > release_body.md
+          awk -v version="$VERSION" '
+            $0 == "## [" version "]" || index($0, "## [" version "] - ") == 1 { found=1; next }
+            found && /^## \[/ { exit }
+            found { print }
+          ' CHANGELOG.md > changelog.txt
+          if [ -n "$RELEASE_DESCRIPTION" ]; then
+            { printf '%s\n\n' "$RELEASE_DESCRIPTION"; cat changelog.txt; } > release_body.md
           else
             cp changelog.txt release_body.md
           fi
@@ -149,26 +157,62 @@ jobs:
           VERSION=${{ steps.version.outputs.version }}
           BOT_NAME="${{ steps.release-token.outputs.app-slug }}[bot]"
           BOT_EMAIL="${{ steps.bot-user.outputs.user-id }}+${{ steps.release-token.outputs.app-slug }}[bot]@users.noreply.github.com"
+          COMMIT_SHA=$(git rev-parse HEAD)
 
-          git config user.name "$BOT_NAME"
-          git config user.email "$BOT_EMAIL"
+          update_file() {
+            local path="$1"
+            local message="$2"
 
-          git add CHANGELOG.md module.json
-          if ! git diff --cached --quiet; then
-            TREE_SHA=$(git write-tree)
-            PARENT_SHA=$(git rev-parse main)
-            gh api /repos/${{ github.repository }}/git/commits \
-              --method POST \
-              --field "sha=$PARENT_SHA" \
-              --field "tree=$TREE_SHA" \
-              --field "message=docs(release): changelog and module.json for ${VERSION} [skip ci]" \
-              --jq .sha
+            FILE_SHA=$(gh api "/repos/${{ github.repository }}/contents/${path}" \
+              --field ref=main \
+              --jq .sha)
+
+            jq -n \
+              --arg message "$message" \
+              --arg content "$(base64 -w 0 "$path")" \
+              --arg sha "$FILE_SHA" \
+              --arg branch "main" \
+              --arg name "$BOT_NAME" \
+              --arg email "$BOT_EMAIL" \
+              '{
+                message: $message,
+                content: $content,
+                sha: $sha,
+                branch: $branch,
+                committer: {name: $name, email: $email},
+                author: {name: $name, email: $email}
+              }' > "/tmp/update-${path//\//-}.json"
+
+            COMMIT_SHA=$(gh api "/repos/${{ github.repository }}/contents/${path}" \
+              --method PUT \
+              --input "/tmp/update-${path//\//-}.json" \
+              --jq .commit.sha)
+          }
+
+          if ! git diff --quiet CHANGELOG.md; then
+            update_file "CHANGELOG.md" "docs(release): changelog for ${VERSION} [skip ci]"
           else
-            echo "No changes to commit"
+            echo "No CHANGELOG.md changes to commit"
           fi
 
-          git tag -a "${VERSION}" -m "Release ${VERSION}"
-          git push origin "${VERSION}"
+          if ! git diff --quiet module.json; then
+            update_file "module.json" "docs(release): module.json for ${VERSION} [skip ci]"
+          else
+            echo "No module.json changes to commit"
+          fi
+
+          TAG_SHA=$(gh api /repos/${{ github.repository }}/git/tags \
+            --method POST \
+            --field "tag=${VERSION}" \
+            --field "message=Release ${VERSION}" \
+            --field "object=${COMMIT_SHA}" \
+            --field "type=commit" \
+            --jq .sha)
+
+          gh api /repos/${{ github.repository }}/git/refs \
+            --method POST \
+            --field "ref=refs/tags/${VERSION}" \
+            --field "sha=${TAG_SHA}"
         env:
           GH_TOKEN: ${{ steps.release-token.outputs.token }}
 

--- a/.github/workflows/update-changelog.yml
+++ b/.github/workflows/update-changelog.yml
@@ -61,7 +61,7 @@ jobs:
             }
             const sections = {};
             const types = {
-              feat: "Features", fix: "Bug Fixes", refactor: "Refactoring",
+              feat: "Added", fix: "Fixed", refactor: "Refactoring",
               perf: "Performance", docs: "Documentation", ci: "CI/CD",
               build: "Build", chore: "Chores", test: "Testing", style: "Styles",
             };
@@ -101,7 +101,7 @@ jobs:
           '
 
       - name: Push changelog update via REST API
-     if: steps.generate.outcome == 'success' && github.event_name == 'push'
+        if: steps.generate.outcome == 'success' && github.event_name == 'push'
         run: |
           if ! git diff --quiet CHANGELOG.md; then
             BOT_NAME="${{ steps.release-token.outputs.app-slug }}[bot]"

--- a/.github/workflows/update-changelog.yml
+++ b/.github/workflows/update-changelog.yml
@@ -1,0 +1,124 @@
+# Post-merge changelog auto-update
+# Generates/updates an [Unreleased] section after every merge to main
+
+name: Update Changelog
+
+'on':
+  push:
+    branches:
+      - main
+
+jobs:
+  update-changelog:
+    runs-on: ubuntu-latest
+    permissions:
+      contents: write
+    if: "!startsWith(github.event.head_commit.message, 'docs(release):')"
+    steps:
+      - name: Generate release bot token
+        id: release-token
+        uses: actions/create-github-app-token@v3
+        with:
+          client-id: ${{ vars.RELEASE_APP_CLIENT_ID }}
+          private-key: ${{ secrets.RELEASE_APP_PRIVATE_KEY }}
+          permission-contents: write
+
+      - name: Checkout
+        uses: actions/checkout@v4
+        with:
+          fetch-depth: 0
+          ref: main
+          token: ${{ steps.release-token.outputs.token }}
+          persist-credentials: true
+
+      - name: Get release bot user id
+        id: bot-user
+        run: |
+          echo "user-id=$(gh api "/users/${{ steps.release-token.outputs.app-slug }}[bot]" --jq .id)" >> "$GITHUB_OUTPUT"
+        env:
+          GH_TOKEN: ${{ steps.release-token.outputs.token }}
+
+      - name: Generate unreleased changelog
+        id: generate
+        continue-on-error: true
+        run: |
+          LAST_TAG=$(git tag --list 'v*' --sort=-version:refname | head -1 | sed 's/^v//')
+          if [ -z "$LAST_TAG" ]; then
+            LAST_TAG=$(git rev-list --max-parents=0 HEAD)
+          fi
+          export LAST_TAG
+          echo "Collecting commits since $LAST_TAG"
+
+          node -e '
+            const { execSync } = require("child_process");
+            const fs = require("fs");
+            const lastTag = process.env.LAST_TAG;
+            const log = execSync(`git log --pretty=format:"%s" ${lastTag}..HEAD`, { encoding: "utf-8" });
+            const commits = log.split("\n").filter(l => l.length > 0 && !l.includes("docs(release):") && !l.includes("docs: update unreleased changelog"));
+            if (commits.length === 0) {
+              console.log("No relevant commits since last tag");
+              process.exit(1);
+            }
+            const sections = {};
+            const types = {
+              feat: "Features", fix: "Bug Fixes", refactor: "Refactoring",
+              perf: "Performance", docs: "Documentation", ci: "CI/CD",
+              build: "Build", chore: "Chores", test: "Testing", style: "Styles",
+            };
+            for (const c of commits) {
+              const m = c.match(/^(feat|fix|refactor|perf|docs|ci|build|chore|test|style)(\(.*?\))?:\s*(.*)/);
+              const type = m ? m[1] : "other";
+              const scope = m ? (m[2] || "") : "";
+              const msg = m ? m[3] : c;
+              const section = sections[type] || [];
+              section.push(scope ? `${scope} ${msg}` : msg);
+              sections[type] = section;
+            }
+            const order = ["feat", "fix", "refactor", "perf", "docs", "ci", "build", "chore", "test", "style", "other"];
+            const date = new Date().toISOString().slice(0, 10);
+            let entry = `## [Unreleased] - ${date}\n`;
+            for (const type of order) {
+              if (!sections[type]) continue;
+              entry += `\n### ${types[type] || "Other"}\n\n`;
+              for (const msg of sections[type]) entry += `- ${msg}\n`;
+            }
+            entry += "\n";
+            const ch = fs.readFileSync("CHANGELOG.md", "utf-8");
+            const unreleasedMarker = "## [Unreleased]";
+            const existing = ch.indexOf(unreleasedMarker);
+            if (existing > 0) {
+              const nextHeader = ch.indexOf("\n## [", existing);
+              const newContent = nextHeader > 0 ? ch.slice(0, existing) + entry + ch.slice(nextHeader) : ch.slice(0, existing) + entry;
+              fs.writeFileSync("CHANGELOG.md", newContent);
+            } else {
+              const firstVer = ch.indexOf("\n## [");
+              const insert = firstVer > 0 ? firstVer : ch.indexOf("## [");
+              const header = ch.slice(0, insert);
+              const rest = ch.slice(insert);
+              fs.writeFileSync("CHANGELOG.md", header + entry + rest);
+            }
+            console.log("Updated unreleased changelog:\n" + entry.trim());
+          '
+
+      - name: Push changelog update via REST API
+     if: steps.generate.outcome == 'success' && github.event_name == 'push'
+        run: |
+          if ! git diff --quiet CHANGELOG.md; then
+            BOT_NAME="${{ steps.release-token.outputs.app-slug }}[bot]"
+            BOT_EMAIL="${{ steps.bot-user.outputs.user-id }}+${{ steps.release-token.outputs.app-slug }}[bot]@users.noreply.github.com"
+            git config user.name "$BOT_NAME"
+            git config user.email "$BOT_EMAIL"
+            git add CHANGELOG.md
+            TREE_SHA=$(git write-tree)
+            PARENT_SHA=$(git rev-parse main)
+            gh api /repos/${{ github.repository }}/git/commits \
+              --method POST \
+              --field "sha=$PARENT_SHA" \
+              --field "tree=$TREE_SHA" \
+              --field 'message="docs: update unreleased changelog [skip ci]"' \
+              --jq .sha
+          else
+            echo "No changes to push"
+          fi
+        env:
+          GH_TOKEN: ${{ steps.release-token.outputs.token }}

--- a/.github/workflows/update-changelog.yml
+++ b/.github/workflows/update-changelog.yml
@@ -13,7 +13,9 @@ jobs:
     runs-on: ubuntu-latest
     permissions:
       contents: write
-    if: "!startsWith(github.event.head_commit.message, 'docs(release):')"
+    if: >-
+      !startsWith(github.event.head_commit.message, 'docs(release):') &&
+      !startsWith(github.event.head_commit.message, 'docs: update unreleased changelog')
     steps:
       - name: Generate release bot token
         id: release-token
@@ -42,18 +44,20 @@ jobs:
         id: generate
         continue-on-error: true
         run: |
-          LAST_TAG=$(git tag --list 'v*' --sort=-version:refname | head -1 | sed 's/^v//')
+          LAST_TAG=$(git tag --list --sort=-version:refname | grep -E '^[v]?[0-9]+\.[0-9]+\.[0-9]+$' | head -1 || true)
           if [ -z "$LAST_TAG" ]; then
-            LAST_TAG=$(git rev-list --max-parents=0 HEAD)
+            LAST_REF=$(git rev-list --max-parents=0 HEAD)
+          else
+            LAST_REF="$LAST_TAG"
           fi
-          export LAST_TAG
-          echo "Collecting commits since $LAST_TAG"
+          export LAST_REF
+          echo "Collecting commits since $LAST_REF"
 
           node -e '
             const { execSync } = require("child_process");
             const fs = require("fs");
-            const lastTag = process.env.LAST_TAG;
-            const log = execSync(`git log --pretty=format:"%s" ${lastTag}..HEAD`, { encoding: "utf-8" });
+            const lastRef = process.env.LAST_REF;
+            const log = execSync(`git log --pretty=format:"%s" ${lastRef}..HEAD`, { encoding: "utf-8" });
             const commits = log.split("\n").filter(l => l.length > 0 && !l.includes("docs(release):") && !l.includes("docs: update unreleased changelog"));
             if (commits.length === 0) {
               console.log("No relevant commits since last tag");
@@ -86,37 +90,51 @@ jobs:
             const ch = fs.readFileSync("CHANGELOG.md", "utf-8");
             const unreleasedMarker = "## [Unreleased]";
             const existing = ch.indexOf(unreleasedMarker);
-            if (existing > 0) {
-              const nextHeader = ch.indexOf("\n## [", existing);
-              const newContent = nextHeader > 0 ? ch.slice(0, existing) + entry + ch.slice(nextHeader) : ch.slice(0, existing) + entry;
+            if (existing >= 0) {
+              const nextHeader = ch.indexOf("\n## [", existing + 1);
+              const newContent = nextHeader > 0 ? ch.slice(0, existing) + entry + ch.slice(nextHeader + 1) : ch.slice(0, existing) + entry;
               fs.writeFileSync("CHANGELOG.md", newContent);
             } else {
-              const firstVer = ch.indexOf("\n## [");
-              const insert = firstVer > 0 ? firstVer : ch.indexOf("## [");
-              const header = ch.slice(0, insert);
-              const rest = ch.slice(insert);
-              fs.writeFileSync("CHANGELOG.md", header + entry + rest);
+              const firstVersionHeader = ch.indexOf("\n## [");
+              if (firstVersionHeader < 0) {
+                throw new Error("CHANGELOG.md has no version header insertion point");
+              }
+              fs.writeFileSync("CHANGELOG.md", ch.slice(0, firstVersionHeader + 1) + entry + ch.slice(firstVersionHeader + 1));
             }
             console.log("Updated unreleased changelog:\n" + entry.trim());
           '
 
-      - name: Push changelog update via REST API
+      - name: Push changelog update via Contents API
         if: steps.generate.outcome == 'success' && github.event_name == 'push'
         run: |
           if ! git diff --quiet CHANGELOG.md; then
             BOT_NAME="${{ steps.release-token.outputs.app-slug }}[bot]"
             BOT_EMAIL="${{ steps.bot-user.outputs.user-id }}+${{ steps.release-token.outputs.app-slug }}[bot]@users.noreply.github.com"
-            git config user.name "$BOT_NAME"
-            git config user.email "$BOT_EMAIL"
-            git add CHANGELOG.md
-            TREE_SHA=$(git write-tree)
-            PARENT_SHA=$(git rev-parse main)
-            gh api /repos/${{ github.repository }}/git/commits \
-              --method POST \
-              --field "sha=$PARENT_SHA" \
-              --field "tree=$TREE_SHA" \
-              --field 'message="docs: update unreleased changelog [skip ci]"' \
-              --jq .sha
+
+            FILE_SHA=$(gh api /repos/${{ github.repository }}/contents/CHANGELOG.md \
+              --field ref=main \
+              --jq .sha)
+
+            jq -n \
+              --arg message "docs: update unreleased changelog [skip ci]" \
+              --arg content "$(base64 -w 0 CHANGELOG.md)" \
+              --arg sha "$FILE_SHA" \
+              --arg branch "main" \
+              --arg name "$BOT_NAME" \
+              --arg email "$BOT_EMAIL" \
+              '{
+                message: $message,
+                content: $content,
+                sha: $sha,
+                branch: $branch,
+                committer: {name: $name, email: $email},
+                author: {name: $name, email: $email}
+              }' > /tmp/update-changelog.json
+
+            gh api /repos/${{ github.repository }}/contents/CHANGELOG.md \
+              --method PUT \
+              --input /tmp/update-changelog.json \
+              --jq .commit.sha
           else
             echo "No changes to push"
           fi

--- a/.github/workflows/update-changelog.yml
+++ b/.github/workflows/update-changelog.yml
@@ -3,7 +3,7 @@
 
 name: Update Changelog
 
-'on':
+"on":
   push:
     branches:
       - main
@@ -41,8 +41,6 @@ jobs:
           GH_TOKEN: ${{ steps.release-token.outputs.token }}
 
       - name: Generate unreleased changelog
-        id: generate
-        continue-on-error: true
         run: |
           LAST_TAG=$(git tag --list --sort=-version:refname | grep -E '^[v]?[0-9]+\.[0-9]+\.[0-9]+$' | head -1 || true)
           if [ -z "$LAST_TAG" ]; then
@@ -58,10 +56,14 @@ jobs:
             const fs = require("fs");
             const lastRef = process.env.LAST_REF;
             const log = execSync(`git log --pretty=format:"%s" ${lastRef}..HEAD`, { encoding: "utf-8" });
-            const commits = log.split("\n").filter(l => l.length > 0 && !l.includes("docs(release):") && !l.includes("docs: update unreleased changelog"));
+            const commits = log
+              .split("\n")
+              .filter(l => l.length > 0)
+              .filter(l => !l.includes("docs(release):"))
+              .filter(l => !l.includes("docs: update unreleased changelog"));
             if (commits.length === 0) {
               console.log("No relevant commits since last tag");
-              process.exit(1);
+              process.exit(0);
             }
             const sections = {};
             const types = {
@@ -70,12 +72,12 @@ jobs:
               build: "Build", chore: "Chores", test: "Testing", style: "Styles",
             };
             for (const c of commits) {
-              const m = c.match(/^(feat|fix|refactor|perf|docs|ci|build|chore|test|style)(\(.*?\))?:\s*(.*)/);
+              const m = c.match(/^(feat|fix|refactor|perf|docs|ci|build|chore|test|style)(\((.*?)\))?:\s*(.*)/);
               const type = m ? m[1] : "other";
-              const scope = m ? (m[2] || "") : "";
-              const msg = m ? m[3] : c;
+              const scope = m && m[3] ? m[3] : "";
+              const msg = m ? m[4] : c;
               const section = sections[type] || [];
-              section.push(scope ? `${scope} ${msg}` : msg);
+              section.push(scope ? `${scope}: ${msg}` : msg);
               sections[type] = section;
             }
             const order = ["feat", "fix", "refactor", "perf", "docs", "ci", "build", "chore", "test", "style", "other"];
@@ -105,7 +107,6 @@ jobs:
           '
 
       - name: Push changelog update via Contents API
-        if: steps.generate.outcome == 'success' && github.event_name == 'push'
         run: |
           if ! git diff --quiet CHANGELOG.md; then
             BOT_NAME="${{ steps.release-token.outputs.app-slug }}[bot]"

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,10 +5,24 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [Unreleased] - 2026-06-13
+
+### Added
+
+- compat: add Foundry v14 support by fixing sidebar rendering regression
+- ci: add Copilot code review workflow with PR gating and testing requirements
+
+### Fixed
+
+- ui: prevent race condition cascade on message cancellation
+- core: fix context compaction overflow and context limit honoring (Fixes #150)
+- core: ensure outgoing tool call arguments are valid JSON (Fixes #145)
+- index: persist hasEverIndexed flag to unblock search_assets on reload (Fixes #126)
 
 ## [1.0.9] - 2026-03-18
 
 ### Changed
+
 - refactor: remove maxResults caps and merge compendium management into document tools
 - feat: add document copy and move tools
 - feat: add compendium create action and rename pack_id to packId
@@ -22,6 +36,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ## [1.0.8] - 2026-02-08
 
 ### Changed
+
 - refactor(benchmark): replace webhook with guided Discord sharing flow
 - chore(benchmark): switch webhook to public channel, drop review language
 - fix(benchmark): note that Discord submissions are reviewed
@@ -53,14 +68,16 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ## [1.0.7] - 2026-02-06
 
 ### Changed
+
 - fix: Ollama integration - race conditions, non-blocking validation, token limit consolidation
 - fix(ci): Fix shell quoting in Discord announcement step
 
 ## [1.0.6] - 2026-02-05
 
 ### Changed
+
 - fix(ui): Restore status bar styling and task tracker regressions
-- fix(ui): Remove leftover _monitorStatus call causing crash
+- fix(ui): Remove leftover \_monitorStatus call causing crash
 - fix(ui): Restore status bar and indexing status logic
 - feat: Add context limit handling and sidebar UI refinements
 - fix: restore tool justification expand/collapse functionality
@@ -75,6 +92,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ## [1.0.5] - 2026-02-03
 
 ### Changed
+
 - fix: preserve textarea content and status area on thinking state change
 - fix: extract proper content summary for direct display tools
 - fix: prevent raw JSON from rendering for direct display tools
@@ -91,6 +109,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ## [1.0.4] - 2026-02-03
 
 ### Changed
+
 - fix: make disabled sidebar tab properly inert and V12 compatibility
 - style: refine Discord link appearance in settings
 - fix: add Discord link to Foundry settings config, remove dead code
@@ -103,11 +122,13 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ## [1.0.3] - 2026-01-31
 
 ### Changed
+
 - fix: restore system-agnostic CSS for Carolingian UX compatibility
 
 ## [1.0.2] - 2026-01-31
 
 ### Changed
+
 - ci: switch to manual workflow_dispatch for releases
 - docs: add CONTRIBUTING.md with commit conventions
 - fix: correct content/display pattern in list_documents tool
@@ -135,9 +156,11 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - fix: prevent context overflow from large tool outputs
 - fix: remove oneOf from execute_macro schema for Anthropic compatibility
 - feat: auto-update CHANGELOG.md on release
+
 ## [1.0.0] - 2026-01-12
 
 ### Added
+
 - Initial public release of Simulacrum: AI Campaign Copilot
 - Natural language document management (create, read, update, delete)
 - Multi-provider AI support (OpenAI, Google Gemini, Anthropic, and OpenAI-compatible APIs)


### PR DESCRIPTION
## Summary

- harden the post-merge changelog workflow so no-change runs exit successfully instead of relying on `continue-on-error`
- normalize generated changelog scopes from `(scope) message` to `scope: message`
- make the release workflow commit `CHANGELOG.md` and `module.json` together through the Git database API instead of two sequential Contents API commits
- create the release tag via GitHub's tag/ref APIs, pointing at the exact release commit

## Verification

- YAML parse validated locally for both workflow files
- Prettier check passed locally for both workflow files
- branch is based on current `main` and is 2 commits ahead / 0 behind
- diff contains only `.github/workflows/update-changelog.yml` and `.github/workflows/create-release.yml`
- removed accidental noop writes from branch history before opening this PR