### PR TITLE
fix(ci): unify release/changelog workflows with Contents API and correct headers

### DIFF
--- a/.github/workflows/create-release.yml
+++ b/.github/workflows/create-release.yml
@@ -109,54 +109,16 @@ jobs:
           cd ..
           mv module.json.release module.json
 
-      - name: Generate changelog from commits
+      - name: Version changelog entry
         run: |
           VERSION=${{ steps.version.outputs.version }}
-          LAST_TAG=$(git tag --list 'v*' --sort=-version:refname | grep -v "$VERSION" | head -1 | sed 's/^v//')
-          if [ -z "$LAST_TAG" ]; then
-            LAST_TAG=$(git rev-list --max-parents=0 HEAD)
+          if grep -q "^## \[Unreleased\]" CHANGELOG.md; then
+            sed -i "s/^## \[Unreleased\] - .*$/## [${VERSION}] - $(date -u +%Y-%m-%d)/" CHANGELOG.md
+            echo "Versioned [Unreleased] entry to [${VERSION}]"
+          elif ! grep -q "^## \[${VERSION}\]" CHANGELOG.md; then
+            echo "::error::CHANGELOG.md is missing both [Unreleased] and [${VERSION}] entry"
+            exit 1
           fi
-          echo "Generating changelog for $VERSION (since $LAST_TAG)"
-          node -e '
-            const { execSync } = require("child_process");
-            const fs = require("fs");
-            const version = "${VERSION}";
-            const lastTag = "${LAST_TAG}";
-            const log = execSync(`git log --pretty=format:"%s" ${lastTag}..HEAD`, { encoding: "utf-8" });
-            const commits = log.split("\n").filter(l => l.length > 0);
-            const sections = {};
-            const types = {
-              feat: "Features", fix: "Bug Fixes", refactor: "Refactoring",
-              perf: "Performance", docs: "Documentation", ci: "CI/CD",
-              build: "Build", chore: "Chores", test: "Testing", style: "Styles",
-            };
-            for (const c of commits) {
-              const m = c.match(/^(feat|fix|refactor|perf|docs|ci|build|chore|test|style)(\(.*?\))?:\s*(.*)/);
-              const type = m ? m[1] : "other";
-              const scope = m ? (m[2] || "") : "";
-              const msg = m ? m[3] : c;
-              const section = sections[type] || [];
-              section.push(scope ? `${scope} ${msg}` : msg);
-              sections[type] = section;
-            }
-            const order = ["feat", "fix", "refactor", "perf", "docs", "ci", "build", "chore", "test", "style", "other"];
-            const date = new Date().toISOString().slice(0, 10);
-            let entry = `## [${version}] - ${date}\n`;
-            for (const type of order) {
-              if (!sections[type]) continue;
-              entry += `\n### ${types[type] || "Other"}\n\n`;
-              for (const msg of sections[type]) entry += `- ${msg}\n`;
-            }
-            entry += "\n";
-            const ch = fs.readFileSync("CHANGELOG.md", "utf-8");
-            const firstVer = ch.indexOf("\n## [");
-            const insert = firstVer > 0 ? firstVer : ch.indexOf("## [");
-            const header = ch.slice(0, insert);
-            const rest = ch.slice(insert);
-            fs.writeFileSync("CHANGELOG.md", header + entry + rest);
-            console.log("Inserted changelog entry:\n" + entry.trim());
-          '
-          echo "version=${{ steps.version.outputs.version }}" >> $GITHUB_ENV
           TITLE="${{ inputs.release_title }}"
           if [ -z "$TITLE" ]; then
             TITLE="v${{ steps.version.outputs.version }}"
@@ -182,19 +144,33 @@ jobs:
         env:
           GH_TOKEN: ${{ steps.release-token.outputs.token }}
 
-      - name: Commit CHANGELOG.md and create tag
+      - name: Commit release updates and create tag
         run: |
           VERSION=${{ steps.version.outputs.version }}
+          BOT_NAME="${{ steps.release-token.outputs.app-slug }}[bot]"
+          BOT_EMAIL="${{ steps.bot-user.outputs.user-id }}+${{ steps.release-token.outputs.app-slug }}[bot]@users.noreply.github.com"
 
-          git config user.name "${{ steps.release-token.outputs.app-slug }}[bot]"
-          git config user.email "${{ steps.bot-user.outputs.user-id }}+${{ steps.release-token.outputs.app-slug }}[bot]@users.noreply.github.com"
+          git config user.name "$BOT_NAME"
+          git config user.email "$BOT_EMAIL"
 
           git add CHANGELOG.md module.json
-          git commit -m "docs(release): update changelog and module.json for ${VERSION} [skip ci]" || echo "No changes to commit"
+          if ! git diff --cached --quiet; then
+            TREE_SHA=$(git write-tree)
+            PARENT_SHA=$(git rev-parse main)
+            gh api /repos/${{ github.repository }}/git/commits \
+              --method POST \
+              --field "sha=$PARENT_SHA" \
+              --field "tree=$TREE_SHA" \
+              --field "message=docs(release): changelog and module.json for ${VERSION} [skip ci]" \
+              --jq .sha
+          else
+            echo "No changes to commit"
+          fi
 
           git tag -a "${VERSION}" -m "Release ${VERSION}"
-          git push origin main
           git push origin "${VERSION}"
+        env:
+          GH_TOKEN: ${{ steps.release-token.outputs.token }}
 
       - name: Create GitHub Release
         uses: softprops/action-gh-release@v1

--- a/.github/workflows/create-release.yml
+++ b/.github/workflows/create-release.yml
@@ -10,6 +10,14 @@ name: Create Release
         description: 'Version to release (e.g., 1.0.2)'
         required: true
         type: string
+      release_title:
+        description: 'Release title (default: v<version>)'
+        required: false
+        type: string
+      release_description:
+        description: 'Release description/shoutbox (prepended to changelog)'
+        required: false
+        type: string
 
 env:
   MODULE_ID: simulacrum
@@ -101,28 +109,71 @@ jobs:
           cd ..
           mv module.json.release module.json
 
-      - name: Verify changelog entry exists
-        id: changelog
+      - name: Generate changelog from commits
         run: |
           VERSION=${{ steps.version.outputs.version }}
-          if ! grep -q "^## \[${VERSION}\]" CHANGELOG.md; then
-            echo "::error::CHANGELOG.md is missing entry for version ${VERSION}"
-            echo "Expected heading: ## [${VERSION}]"
-            exit 1
+          LAST_TAG=$(git tag --list 'v*' --sort=-version:refname | grep -v "$VERSION" | head -1 | sed 's/^v//')
+          if [ -z "$LAST_TAG" ]; then
+            LAST_TAG=$(git rev-list --max-parents=0 HEAD)
           fi
-          echo "Changelog entry for ${VERSION} found"
+          echo "Generating changelog for $VERSION (since $LAST_TAG)"
+          node -e '
+            const { execSync } = require("child_process");
+            const fs = require("fs");
+            const version = "${VERSION}";
+            const lastTag = "${LAST_TAG}";
+            const log = execSync(`git log --pretty=format:"%s" ${lastTag}..HEAD`, { encoding: "utf-8" });
+            const commits = log.split("\n").filter(l => l.length > 0);
+            const sections = {};
+            const types = {
+              feat: "Features", fix: "Bug Fixes", refactor: "Refactoring",
+              perf: "Performance", docs: "Documentation", ci: "CI/CD",
+              build: "Build", chore: "Chores", test: "Testing", style: "Styles",
+            };
+            for (const c of commits) {
+              const m = c.match(/^(feat|fix|refactor|perf|docs|ci|build|chore|test|style)(\(.*?\))?:\s*(.*)/);
+              const type = m ? m[1] : "other";
+              const scope = m ? (m[2] || "") : "";
+              const msg = m ? m[3] : c;
+              const section = sections[type] || [];
+              section.push(scope ? `${scope} ${msg}` : msg);
+              sections[type] = section;
+            }
+            const order = ["feat", "fix", "refactor", "perf", "docs", "ci", "build", "chore", "test", "style", "other"];
+            const date = new Date().toISOString().slice(0, 10);
+            let entry = `## [${version}] - ${date}\n`;
+            for (const type of order) {
+              if (!sections[type]) continue;
+              entry += `\n### ${types[type] || "Other"}\n\n`;
+              for (const msg of sections[type]) entry += `- ${msg}\n`;
+            }
+            entry += "\n";
+            const ch = fs.readFileSync("CHANGELOG.md", "utf-8");
+            const firstVer = ch.indexOf("\n## [");
+            const insert = firstVer > 0 ? firstVer : ch.indexOf("## [");
+            const header = ch.slice(0, insert);
+            const rest = ch.slice(insert);
+            fs.writeFileSync("CHANGELOG.md", header + entry + rest);
+            console.log("Inserted changelog entry:\n" + entry.trim());
+          '
+          echo "version=${{ steps.version.outputs.version }}" >> $GITHUB_ENV
+          TITLE="${{ inputs.release_title }}"
+          if [ -z "$TITLE" ]; then
+            TITLE="v${{ steps.version.outputs.version }}"
+          fi
+          echo "RELEASE_TITLE=$TITLE" >> $GITHUB_ENV
 
-      - name: Extract changelog body for release
+      - name: Prepare release body
         run: |
           VERSION=${{ steps.version.outputs.version }}
-          # Extract lines after the version heading until the next heading or end of file
           awk "/^## \[${VERSION}\]/{found=1; next} /^## \[[0-9]/{exit} found{print}" CHANGELOG.md > changelog.txt
-          if [ ! -s changelog.txt ]; then
-            echo "::error::Changelog body for ${VERSION} is empty"
-            exit 1
+          if [ -n "${{ inputs.release_description }}" ]; then
+            { printf '%s\n\n' "${{ inputs.release_description }}"; cat changelog.txt; } > release_body.md
+          else
+            cp changelog.txt release_body.md
           fi
-          echo "Extracted changelog body:"
-          cat changelog.txt
+          echo "Release body:"
+          cat release_body.md
 
       - name: Get release bot user id
         id: bot-user
@@ -138,8 +189,8 @@ jobs:
           git config user.name "${{ steps.release-token.outputs.app-slug }}[bot]"
           git config user.email "${{ steps.bot-user.outputs.user-id }}+${{ steps.release-token.outputs.app-slug }}[bot]@users.noreply.github.com"
 
-          git add CHANGELOG.md
-          git commit -m "docs(release): update generated changelog for ${VERSION} [skip ci]" || echo "No changes to commit"
+          git add CHANGELOG.md module.json
+          git commit -m "docs(release): update changelog and module.json for ${VERSION} [skip ci]" || echo "No changes to commit"
 
           git tag -a "${VERSION}" -m "Release ${VERSION}"
           git push origin main
@@ -149,8 +200,8 @@ jobs:
         uses: softprops/action-gh-release@v1
         with:
           tag_name: ${{ steps.version.outputs.version }}
-          name: 'v${{ steps.version.outputs.version }}'
-          body_path: changelog.txt
+          name: ${{ env.RELEASE_TITLE }}
+          body_path: release_body.md
           files: |
             module.json
             ${{ env.MODULE_ID }}.zip

--- a/.github/workflows/create-release.yml
+++ b/.github/workflows/create-release.yml
@@ -105,9 +105,7 @@ jobs:
           cd dist
           zip -r ${{ env.MODULE_ID }}.zip ${{ env.MODULE_ID }}
           mv ${{ env.MODULE_ID }}.zip ../
-          cp ${{ env.MODULE_ID }}/module.json ../module.json.release
           cd ..
-          mv module.json.release module.json
 
       - name: Version changelog entry
         run: |
@@ -144,30 +142,35 @@ jobs:
         env:
           GH_TOKEN: ${{ steps.release-token.outputs.token }}
 
-      - name: Commit release updates and create tag
+      - name: Commit release updates via Contents API
         run: |
           VERSION=${{ steps.version.outputs.version }}
           BOT_NAME="${{ steps.release-token.outputs.app-slug }}[bot]"
           BOT_EMAIL="${{ steps.bot-user.outputs.user-id }}+${{ steps.release-token.outputs.app-slug }}[bot]@users.noreply.github.com"
 
-          git config user.name "$BOT_NAME"
-          git config user.email "$BOT_EMAIL"
+          # Update CHANGELOG.md via Contents API
+          CHANGELOG_SHA=$(gh api /repos/${{ github.repository }}/contents/CHANGELOG.md --jq .sha)
+          CHANGELOG_CONTENT=$(base64 -w 0 CHANGELOG.md)
+          printf '{"message":"docs(release): update changelog for ${VERSION} [skip ci]","content":"%s","sha":"%s","branch":"main","committer":{"name":"%s","email":"%s"},"author":{"name":"%s","email":"%s"}}' \
+            "$CHANGELOG_CONTENT" "$CHANGELOG_SHA" "$BOT_NAME" "$BOT_EMAIL" "$BOT_NAME" "$BOT_EMAIL" \
+            | gh api /repos/${{ github.repository }}/contents/CHANGELOG.md --method PUT --input - --jq .commit.sha
+          echo "CHANGELOG.md committed"
 
-          git add CHANGELOG.md module.json
-          if ! git diff --cached --quiet; then
-            TREE_SHA=$(git write-tree)
-            PARENT_SHA=$(git rev-parse main)
-            gh api /repos/${{ github.repository }}/git/commits \
-              --method POST \
-              --field "sha=$PARENT_SHA" \
-              --field "tree=$TREE_SHA" \
-              --field "message=docs(release): changelog and module.json for ${VERSION} [skip ci]" \
-              --jq .sha
-          else
-            echo "No changes to commit"
-          fi
+          # Update module.json via Contents API
+          MODULE_SHA=$(gh api /repos/${{ github.repository }}/contents/module.json --jq .sha)
+          MODULE_CONTENT=$(base64 -w 0 module.json)
+          printf '{"message":"docs(release): update module.json for ${VERSION} [skip ci]","content":"%s","sha":"%s","branch":"main","committer":{"name":"%s","email":"%s"},"author":{"name":"%s","email":"%s"}}' \
+            "$MODULE_CONTENT" "$MODULE_SHA" "$BOT_NAME" "$BOT_EMAIL" "$BOT_NAME" "$BOT_EMAIL" \
+            | gh api /repos/${{ github.repository }}/contents/module.json --method PUT --input - --jq .commit.sha
+          echo "module.json committed"
+        env:
+          GH_TOKEN: ${{ steps.release-token.outputs.token }}
 
-          git tag -a "${VERSION}" -m "Release ${VERSION}"
+      - name: Create tag and push
+        run: |
+          VERSION=${{ steps.version.outputs.version }}
+          git fetch origin main
+          git tag -a "${VERSION}" -m "Release ${VERSION}" FETCH_HEAD
           git push origin "${VERSION}"
         env:
           GH_TOKEN: ${{ steps.release-token.outputs.token }}
@@ -212,19 +215,16 @@ jobs:
           VERSION=${{ steps.version.outputs.version }}
           REPO_URL="https://github.com/${{ github.repository }}"
           RELEASE_URL="${REPO_URL}/releases/tag/${VERSION}"
-          # Discord field value limit is 1024 chars - truncate by lines until under limit
           SUFFIX=$'\n'"[See full release notes](${RELEASE_URL})"
           MAX_CHARS=$((1024 - ${#SUFFIX} - 10))
           CHANGELOG=$(cat changelog.txt)
           while [ ${#CHANGELOG} -gt $MAX_CHARS ]; do
-            # Drop the last line and append truncation notice
             CHANGELOG=$(echo "$CHANGELOG" | head -n -1)
           done
           if [ ${#CHANGELOG} -lt $(wc -c < changelog.txt) ]; then
             CHANGELOG="${CHANGELOG}${SUFFIX}"
           fi
 
-          # Build JSON payload with proper escaping using jq
           PAYLOAD=$(jq -n \
             --arg title "Simulacrum v${VERSION} Released!" \
             --arg url "$RELEASE_URL" \

--- a/.github/workflows/create-release.yml
+++ b/.github/workflows/create-release.yml
@@ -3,7 +3,7 @@
 
 name: Create Release
 
-"on":
+'on':
   workflow_dispatch:
     inputs:
       version:
@@ -21,11 +21,21 @@ jobs:
       contents: write
 
     steps:
+      - name: Generate release bot token
+        id: release-token
+        uses: actions/create-github-app-token@v3
+        with:
+          client-id: ${{ vars.RELEASE_APP_CLIENT_ID }}
+          private-key: ${{ secrets.RELEASE_APP_PRIVATE_KEY }}
+          permission-contents: write
+
       - name: Checkout
         uses: actions/checkout@v4
         with:
           fetch-depth: 0
           ref: main
+          token: ${{ steps.release-token.outputs.token }}
+          persist-credentials: true
 
       - name: Setup Node.js
         uses: actions/setup-node@v4
@@ -91,45 +101,46 @@ jobs:
           cd ..
           mv module.json.release module.json
 
-      - name: Generate changelog
+      - name: Verify changelog entry exists
         id: changelog
         run: |
           VERSION=${{ steps.version.outputs.version }}
-          TODAY=$(date +%Y-%m-%d)
-          PREV_TAG=$(git describe --tags --abbrev=0 HEAD 2>/dev/null || echo "")
-          if [ -n "$PREV_TAG" ]; then
-            echo "Generating changelog from $PREV_TAG to HEAD"
-            COMMITS=$(git log --pretty=format:"- %s" $PREV_TAG..HEAD | grep -vE '^- (docs|ci|chore):')
-          else
-            echo "No previous tag found, including recent commits"
-            COMMITS=$(git log --pretty=format:"- %s" HEAD~10..HEAD 2>/dev/null || git log --pretty=format:"- %s" | grep -vE '^- (docs|ci|chore):')
+          if ! grep -q "^## \[${VERSION}\]" CHANGELOG.md; then
+            echo "::error::CHANGELOG.md is missing entry for version ${VERSION}"
+            echo "Expected heading: ## [${VERSION}]"
+            exit 1
           fi
-          # Ensure we have at least something for the changelog
-          if [ -z "$COMMITS" ]; then
-            COMMITS="- Maintenance release"
-          fi
-          echo "$COMMITS" > changelog.txt
-          cat > new_entry.txt << 'ENTRY_EOF'
-          ## [$VERSION] - $TODAY
+          echo "Changelog entry for ${VERSION} found"
 
-          ### Changed
-          ENTRY_EOF
-          sed -i "s/\$VERSION/$VERSION/g; s/\$TODAY/$TODAY/g" new_entry.txt
-          echo "$COMMITS" >> new_entry.txt
-          head -n 7 CHANGELOG.md > CHANGELOG.tmp
-          echo "" >> CHANGELOG.tmp
-          cat new_entry.txt >> CHANGELOG.tmp
-          tail -n +8 CHANGELOG.md >> CHANGELOG.tmp
-          mv CHANGELOG.tmp CHANGELOG.md
-          rm new_entry.txt
+      - name: Extract changelog body for release
+        run: |
+          VERSION=${{ steps.version.outputs.version }}
+          # Extract lines after the version heading until the next heading or end of file
+          awk "/^## \[${VERSION}\]/{found=1; next} /^## \[[0-9]/{exit} found{print}" CHANGELOG.md > changelog.txt
+          if [ ! -s changelog.txt ]; then
+            echo "::error::Changelog body for ${VERSION} is empty"
+            exit 1
+          fi
+          echo "Extracted changelog body:"
+          cat changelog.txt
+
+      - name: Get release bot user id
+        id: bot-user
+        run: |
+          echo "user-id=$(gh api "/users/${{ steps.release-token.outputs.app-slug }}[bot]" --jq .id)" >> "$GITHUB_OUTPUT"
+        env:
+          GH_TOKEN: ${{ steps.release-token.outputs.token }}
 
       - name: Commit CHANGELOG.md and create tag
         run: |
           VERSION=${{ steps.version.outputs.version }}
-          git config user.name "github-actions[bot]"
-          git config user.email "github-actions[bot]@users.noreply.github.com"
+
+          git config user.name "${{ steps.release-token.outputs.app-slug }}[bot]"
+          git config user.email "${{ steps.bot-user.outputs.user-id }}+${{ steps.release-token.outputs.app-slug }}[bot]@users.noreply.github.com"
+
           git add CHANGELOG.md
-          git commit -m "docs: update CHANGELOG.md for ${VERSION}" || echo "No changes to commit"
+          git commit -m "docs(release): update generated changelog for ${VERSION} [skip ci]" || echo "No changes to commit"
+
           git tag -a "${VERSION}" -m "Release ${VERSION}"
           git push origin main
           git push origin "${VERSION}"
@@ -138,14 +149,14 @@ jobs:
         uses: softprops/action-gh-release@v1
         with:
           tag_name: ${{ steps.version.outputs.version }}
-          name: "v${{ steps.version.outputs.version }}"
+          name: 'v${{ steps.version.outputs.version }}'
           body_path: changelog.txt
           files: |
             module.json
             ${{ env.MODULE_ID }}.zip
           fail_on_unmatched_files: true
         env:
-          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+          GITHUB_TOKEN: ${{ steps.release-token.outputs.token }}
 
       - name: Publish to Foundry VTT
         env:

--- a/.github/workflows/update-changelog.yml
+++ b/.github/workflows/update-changelog.yml
@@ -13,7 +13,9 @@ jobs:
     runs-on: ubuntu-latest
     permissions:
       contents: write
-    if: "!startsWith(github.event.head_commit.message, 'docs(release):')"
+    if: >-
+      !startsWith(github.event.head_commit.message, 'docs(release):')
+      && !contains(github.event.head_commit.message, '[skip ci]')
     steps:
       - name: Generate release bot token
         id: release-token
@@ -54,14 +56,14 @@ jobs:
             const fs = require("fs");
             const lastTag = process.env.LAST_TAG;
             const log = execSync(`git log --pretty=format:"%s" ${lastTag}..HEAD`, { encoding: "utf-8" });
-            const commits = log.split("\n").filter(l => l.length > 0 && !l.includes("docs(release):") && !l.includes("docs: update unreleased changelog"));
+            const commits = log.split("\n").filter(l => l.length > 0 && !l.includes("docs(release):") && !l.includes("[skip ci]"));
             if (commits.length === 0) {
               console.log("No relevant commits since last tag");
               process.exit(1);
             }
             const sections = {};
             const types = {
-              feat: "Features", fix: "Bug Fixes", refactor: "Refactoring",
+              feat: "Added", fix: "Fixed", refactor: "Refactoring",
               perf: "Performance", docs: "Documentation", ci: "CI/CD",
               build: "Build", chore: "Chores", test: "Testing", style: "Styles",
             };
@@ -100,23 +102,19 @@ jobs:
             console.log("Updated unreleased changelog:\n" + entry.trim());
           '
 
-      - name: Push changelog update via REST API
-     if: steps.generate.outcome == 'success' && github.event_name == 'push'
+      - name: Push changelog update via Contents API
+        if: steps.generate.outcome == 'success'
+        continue-on-error: true
         run: |
           if ! git diff --quiet CHANGELOG.md; then
             BOT_NAME="${{ steps.release-token.outputs.app-slug }}[bot]"
             BOT_EMAIL="${{ steps.bot-user.outputs.user-id }}+${{ steps.release-token.outputs.app-slug }}[bot]@users.noreply.github.com"
-            git config user.name "$BOT_NAME"
-            git config user.email "$BOT_EMAIL"
-            git add CHANGELOG.md
-            TREE_SHA=$(git write-tree)
-            PARENT_SHA=$(git rev-parse main)
-            gh api /repos/${{ github.repository }}/git/commits \
-              --method POST \
-              --field "sha=$PARENT_SHA" \
-              --field "tree=$TREE_SHA" \
-              --field 'message="docs: update unreleased changelog [skip ci]"' \
-              --jq .sha
+            CURRENT_SHA=$(gh api /repos/${{ github.repository }}/contents/CHANGELOG.md --jq .sha)
+            NEW_CONTENT=$(base64 -w 0 CHANGELOG.md)
+
+            printf '{"message":"docs: update unreleased changelog [skip ci]","content":"%s","sha":"%s","branch":"main","committer":{"name":"%s","email":"%s"},"author":{"name":"%s","email":"%s"}}' \
+              "$NEW_CONTENT" "$CURRENT_SHA" "$BOT_NAME" "$BOT_EMAIL" "$BOT_NAME" "$BOT_EMAIL" \
+              | gh api /repos/${{ github.repository }}/contents/CHANGELOG.md --method PUT --input -
           else
             echo "No changes to push"
           fi

--- a/.github/workflows/update-changelog.yml
+++ b/.github/workflows/update-changelog.yml
@@ -1,0 +1,124 @@
+# Post-merge changelog auto-update
+# Generates/updates an [Unreleased] section after every merge to main
+
+name: Update Changelog
+
+'on':
+  push:
+    branches:
+      - main
+
+jobs:
+  update-changelog:
+    runs-on: ubuntu-latest
+    permissions:
+      contents: write
+    if: "!startsWith(github.event.head_commit.message, 'docs(release):')"
+    steps:
+      - name: Generate release bot token
+        id: release-token
+        uses: actions/create-github-app-token@v3
+        with:
+          client-id: ${{ vars.RELEASE_APP_CLIENT_ID }}
+          private-key: ${{ secrets.RELEASE_APP_PRIVATE_KEY }}
+          permission-contents: write
+
+      - name: Checkout
+        uses: actions/checkout@v4
+        with:
+          fetch-depth: 0
+          ref: main
+          token: ${{ steps.release-token.outputs.token }}
+          persist-credentials: true
+
+      - name: Get release bot user id
+        id: bot-user
+        run: |
+          echo "user-id=$(gh api "/users/${{ steps.release-token.outputs.app-slug }}[bot]" --jq .id)" >> "$GITHUB_OUTPUT"
+        env:
+          GH_TOKEN: ${{ steps.release-token.outputs.token }}
+
+      - name: Generate unreleased changelog
+        id: generate
+        continue-on-error: true
+        run: |
+          LAST_TAG=$(git tag --list 'v*' --sort=-version:refname | head -1 | sed 's/^v//')
+          if [ -z "$LAST_TAG" ]; then
+            LAST_TAG=$(git rev-list --max-parents=0 HEAD)
+          fi
+          export LAST_TAG
+          echo "Collecting commits since $LAST_TAG"
+
+          node -e '
+            const { execSync } = require("child_process");
+            const fs = require("fs");
+            const lastTag = process.env.LAST_TAG;
+            const log = execSync(`git log --pretty=format:"%s" ${lastTag}..HEAD`, { encoding: "utf-8" });
+            const commits = log.split("\n").filter(l => l.length > 0 && !l.includes("docs(release):") && !l.includes("docs: update unreleased changelog"));
+            if (commits.length === 0) {
+              console.log("No relevant commits since last tag");
+              process.exit(1);
+            }
+            const sections = {};
+            const types = {
+              feat: "Features", fix: "Bug Fixes", refactor: "Refactoring",
+              perf: "Performance", docs: "Documentation", ci: "CI/CD",
+              build: "Build", chore: "Chores", test: "Testing", style: "Styles",
+            };
+            for (const c of commits) {
+              const m = c.match(/^(feat|fix|refactor|perf|docs|ci|build|chore|test|style)(\(.*?\))?:\s*(.*)/);
+              const type = m ? m[1] : "other";
+              const scope = m ? (m[2] || "") : "";
+              const msg = m ? m[3] : c;
+              const section = sections[type] || [];
+              section.push(scope ? `${scope} ${msg}` : msg);
+              sections[type] = section;
+            }
+            const order = ["feat", "fix", "refactor", "perf", "docs", "ci", "build", "chore", "test", "style", "other"];
+            const date = new Date().toISOString().slice(0, 10);
+            let entry = `## [Unreleased] - ${date}\n`;
+            for (const type of order) {
+              if (!sections[type]) continue;
+              entry += `\n### ${types[type] || "Other"}\n\n`;
+              for (const msg of sections[type]) entry += `- ${msg}\n`;
+            }
+            entry += "\n";
+            const ch = fs.readFileSync("CHANGELOG.md", "utf-8");
+            const unreleasedMarker = "## [Unreleased]";
+            const existing = ch.indexOf(unreleasedMarker);
+            if (existing > 0) {
+              const nextHeader = ch.indexOf("\n## [", existing);
+              const newContent = nextHeader > 0 ? ch.slice(0, existing) + entry + ch.slice(nextHeader) : ch.slice(0, existing) + entry;
+              fs.writeFileSync("CHANGELOG.md", newContent);
+            } else {
+              const firstVer = ch.indexOf("\n## [");
+              const insert = firstVer > 0 ? firstVer : ch.indexOf("## [");
+              const header = ch.slice(0, insert);
+              const rest = ch.slice(insert);
+              fs.writeFileSync("CHANGELOG.md", header + entry + rest);
+            }
+            console.log("Updated unreleased changelog:\n" + entry.trim());
+          '
+
+      - name: Push changelog update via REST API
+     if: steps.generate.outcome == 'success' && github.event_name == 'push'
+        run: |
+          if ! git diff --quiet CHANGELOG.md; then
+            BOT_NAME="${{ steps.release-token.outputs.app-slug }}[bot]"
+            BOT_EMAIL="${{ steps.bot-user.outputs.user-id }}+${{ steps.release-token.outputs.app-slug }}[bot]@users.noreply.github.com"
+            git config user.name "$BOT_NAME"
+            git config user.email "$BOT_EMAIL"
+            git add CHANGELOG.md
+            TREE_SHA=$(git write-tree)
+            PARENT_SHA=$(git rev-parse main)
+            gh api /repos/${{ github.repository }}/git/commits \
+              --method POST \
+              --field "sha=$PARENT_SHA" \
+              --field "tree=$TREE_SHA" \
+              --field 'message="docs: update unreleased changelog [skip ci]"' \
+              --jq .sha
+          else
+            echo "No changes to push"
+          fi
+        env:
+          GH_TOKEN: ${{ steps.release-token.outputs.token }}


### PR DESCRIPTION
## Summary

Squash-fix for the 8-PR release/changelog GitHub Actions mess (#156–#163). Single commit that actually works.

### Root causes fixed
- **Orphaned commits**: Both workflows used the Git Commits API (`POST /git/commits`), which creates commits that are never attached to any branch. Replaced with the Contents API (`PUT /contents/`) which creates real commits on `main`.
- **Bad YAML indentation**: `update-changelog.yml` had the `if:` condition indented at column 5 instead of column 8, breaking step-level gating.
- **Wrong section headers**: Changelog generated `### Features` / `### Bug Fixes` instead of `### Added` / `### Fixed` per Keep a Changelog spec.
- **Infinite workflow loop**: No `[skip ci]` guard — the bot's own changelog push could trigger another run. Added `!contains(message, '[skip ci]')` to the job-level `if`.
- **Missing fetch before tag**: Release workflow tagged HEAD locally instead of fetching latest `main` first, so tags could point to stale commits.

### Changes
- **update-changelog.yml**: Contents API, correct indentation, correct headers, `[skip ci]` guard, `continue-on-error`
- **create-release.yml**: Contents API for both CHANGELOG.md and module.json, `[skip ci]` commit messages, `git fetch origin main` before tagging, cleaned up redundant module.json restore