### PR TITLE
Consolidate release automation cleanup

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -1,16 +1,8 @@
 # CI checks for pull requests
-# Lint and format run only against the changed files selected by this workflow's
-# pathspecs (scripts/**, tests/**, root *.json / *.md), so pre-existing debt in
-# untouched files does not block unrelated PRs. Dead-code (knip) is inherently a
-# whole-project analysis, so it runs across the repo on both HEAD and the PR
-# base and fails only on findings newly introduced by the PR (baseline-diff).
-# When a config file (.eslintrc.cjs / .prettierrc.json / knip.json) changes,
-# every check runs against the whole project instead, since a config change
-# can flip results anywhere.
 
 name: CI
 
-'on':
+on:
   pull_request:
     branches: [main]
     types: [opened, synchronize, reopened]
@@ -41,53 +33,50 @@ jobs:
           BASE_SHA=${{ github.event.pull_request.base.sha }}
           HEAD_SHA=${{ github.event.pull_request.head.sha }}
 
-          # Check if lint/format config files changed (triggers full project checks).
-          # Include D so deletions of a config file also trigger a full run.
           CONFIG_CHANGED=$(git diff --name-only --diff-filter=ACMRD "$BASE_SHA" "$HEAD_SHA" -- '.eslintrc.cjs' '.prettierrc.json' 'knip.json' | tr '\n' ' ')
           if [ -n "$CONFIG_CHANGED" ]; then
-            echo "config_changed=true" >> $GITHUB_OUTPUT
-            echo "Config files changed: $CONFIG_CHANGED — will run full project checks"
+            echo "config_changed=true" >> "$GITHUB_OUTPUT"
+            echo "Config files changed: $CONFIG_CHANGED — running full checks"
           else
-            echo "config_changed=false" >> $GITHUB_OUTPUT
+            echo "config_changed=false" >> "$GITHUB_OUTPUT"
           fi
 
-          # Extant changed JS files (for eslint/prettier, which can't lint a
-          # deleted path). ACMR excludes D because the file no longer exists.
-          CHANGED_JS=$(git diff --name-only --diff-filter=ACMR "$BASE_SHA" "$HEAD_SHA" -- 'scripts/*.js' 'scripts/**/*.js' 'tests/**/*.js' | tr '\n' ' ')
-          CHANGED_ALL=$(git diff --name-only --diff-filter=ACMR "$BASE_SHA" "$HEAD_SHA" -- 'scripts/*.js' 'scripts/**/*.js' 'tests/**/*.js' '*.json' '*.md' | tr '\n' ' ')
-
-          # Any JS touched (including deletions) — used only to decide whether
-          # the dead-code gate must run. Deleting a JS file can leave other
-          # files newly unreferenced, so D must trigger the gate too.
-          CHANGED_JS_ANY=$(git diff --name-only --diff-filter=ACMRD "$BASE_SHA" "$HEAD_SHA" -- 'scripts/*.js' 'scripts/**/*.js' 'tests/**/*.js' | tr '\n' ' ')
-
-          echo "js_files=$CHANGED_JS" >> $GITHUB_OUTPUT
-          echo "all_files=$CHANGED_ALL" >> $GITHUB_OUTPUT
-
-          if [ -z "$CHANGED_JS" ]; then
-            echo "has_js=false" >> $GITHUB_OUTPUT
-            echo "No JS files changed"
+          WORKFLOW_CHANGED_FILES=$(git diff --name-only --diff-filter=ACMR "$BASE_SHA" "$HEAD_SHA" -- '.github/workflows/*.yml' '.github/workflows/*.yaml' | tr '\n' ' ')
+          if [ -n "$WORKFLOW_CHANGED_FILES" ]; then
+            echo "workflow_changed=true" >> "$GITHUB_OUTPUT"
+            echo "workflow_files=$WORKFLOW_CHANGED_FILES" >> "$GITHUB_OUTPUT"
           else
-            echo "has_js=true" >> $GITHUB_OUTPUT
-            echo "Changed JS files: $CHANGED_JS"
+            echo "workflow_changed=false" >> "$GITHUB_OUTPUT"
           fi
 
-          # Knip also reports unused/missing dependencies, so dep-manifest-only
-          # changes must still run the dead-code check. Include D so deletions of
-          # a manifest also trigger the gate.
+          CHANGED_JS=$(git diff --name-only --diff-filter=ACMR "$BASE_SHA" "$HEAD_SHA" -- 'scripts/*.js' 'scripts/**/*.js' 'tests/**/*.js' 'tools/**/*.js' 'tools/**/*.mjs' | tr '\n' ' ')
+          CHANGED_ALL=$(git diff --name-only --diff-filter=ACMR "$BASE_SHA" "$HEAD_SHA" -- 'scripts/*.js' 'scripts/**/*.js' 'tests/**/*.js' 'tools/**/*.js' 'tools/**/*.mjs' '*.json' '*.md' '.github/workflows/*.yml' '.github/workflows/*.yaml' | tr '\n' ' ')
+          CHANGED_JS_ANY=$(git diff --name-only --diff-filter=ACMRD "$BASE_SHA" "$HEAD_SHA" -- 'scripts/*.js' 'scripts/**/*.js' 'tests/**/*.js' 'tools/**/*.js' 'tools/**/*.mjs' | tr '\n' ' ')
           CHANGED_DEPS=$(git diff --name-only --diff-filter=ACMRD "$BASE_SHA" "$HEAD_SHA" -- 'package.json' 'package-lock.json' | tr '\n' ' ')
-          if [ -n "$CHANGED_JS_ANY" ] || [ -n "$CHANGED_DEPS" ]; then
-            echo "run_deadcode=true" >> $GITHUB_OUTPUT
+
+          echo "js_files=$CHANGED_JS" >> "$GITHUB_OUTPUT"
+          echo "all_files=$CHANGED_ALL" >> "$GITHUB_OUTPUT"
+          echo "workflow_files=$WORKFLOW_CHANGED_FILES" >> "$GITHUB_OUTPUT"
+
+          if [ -n "$CHANGED_JS" ]; then
+            echo "has_js=true" >> "$GITHUB_OUTPUT"
+            echo "Changed JS files: $CHANGED_JS"
           else
-            echo "run_deadcode=false" >> $GITHUB_OUTPUT
+            echo "has_js=false" >> "$GITHUB_OUTPUT"
           fi
 
-          if [ -z "$CHANGED_ALL" ]; then
-            echo "has_any=false" >> $GITHUB_OUTPUT
-            echo "No formattable files changed"
+          if [ -n "$CHANGED_JS_ANY" ] || [ -n "$CHANGED_DEPS" ]; then
+            echo "run_deadcode=true" >> "$GITHUB_OUTPUT"
           else
-            echo "has_any=true" >> $GITHUB_OUTPUT
+            echo "run_deadcode=false" >> "$GITHUB_OUTPUT"
+          fi
+
+          if [ -n "$CHANGED_ALL" ]; then
+            echo "has_any=true" >> "$GITHUB_OUTPUT"
             echo "Changed files for formatting: $CHANGED_ALL"
+          else
+            echo "has_any=false" >> "$GITHUB_OUTPUT"
+            echo "No files for formatting"
           fi
 
       - name: ESLint check (full — config changed)
@@ -102,6 +91,10 @@ jobs:
         if: steps.changed.outputs.config_changed == 'true'
         run: npm run format:check
 
+      - name: Workflow YAML parse check
+        if: steps.changed.outputs.workflow_changed == 'true'
+        run: npx prettier --check ${{ steps.changed.outputs.workflow_files }}
+
       - name: Prettier check (changed files only)
         if: steps.changed.outputs.config_changed == 'false' && steps.changed.outputs.has_any == 'true'
         run: npx prettier --check ${{ steps.changed.outputs.all_files }}
@@ -110,10 +103,6 @@ jobs:
         if: steps.changed.outputs.config_changed == 'true'
         run: npm run dead-code
 
-      # Baseline-diff: run knip on HEAD and on the PR base, fail only on findings
-      # newly introduced by this PR. Pre-existing dead code does not block; new
-      # dead code does — including the case where editing file A leaves file B
-      # newly unreferenced (knip reports B, the diff still catches it).
       - name: Dead code check (baseline diff)
         if: steps.changed.outputs.config_changed == 'false' && steps.changed.outputs.run_deadcode == 'true'
         run: .github/scripts/dead-code-diff.sh "${{ github.event.pull_request.base.sha }}"

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -14,14 +14,14 @@ jobs:
 
     steps:
       - name: Checkout
-        uses: actions/checkout@v4
+        uses: actions/checkout@v6
         with:
           fetch-depth: 0
 
       - name: Setup Node.js
-        uses: actions/setup-node@v4
+        uses: actions/setup-node@v6
         with:
-          node-version: '20'
+          node-version: '24'
           cache: 'npm'
 
       - name: Install dependencies

--- a/.github/workflows/create-release.yml
+++ b/.github/workflows/create-release.yml
@@ -1,15 +1,29 @@
 # FoundryVTT Module Release Workflow
-# Manual trigger only - run with: gh workflow run release.yml -f version=1.0.2
+# Manual trigger only - run with:
+# gh workflow run create-release.yml -f version=1.0.2 -f release_title="Simulacrum 1.0.2" -f release_description="..." -f dry_run=false
 
 name: Create Release
 
-"on":
+on:
   workflow_dispatch:
     inputs:
       version:
-        description: 'Version to release (e.g., 1.0.2)'
+        description: 'SemVer to release (for example: 1.0.2)'
         required: true
         type: string
+      release_title:
+        description: 'Release title (required)'
+        required: true
+        type: string
+      release_description:
+        description: 'Release notes description to prepend (required)'
+        required: true
+        type: string
+      dry_run:
+        description: 'Validate release metadata and payloads without mutating GitHub'
+        required: false
+        type: boolean
+        default: true
 
 env:
   MODULE_ID: simulacrum
@@ -19,13 +33,49 @@ jobs:
     runs-on: ubuntu-latest
     permissions:
       contents: write
-
     steps:
+      - name: Generate release bot token
+        id: release-token
+        uses: actions/create-github-app-token@v3
+        with:
+          client-id: ${{ vars.RELEASE_APP_CLIENT_ID }}
+          private-key: ${{ secrets.RELEASE_APP_PRIVATE_KEY }}
+          permission-contents: write
+
       - name: Checkout
         uses: actions/checkout@v4
         with:
           fetch-depth: 0
-          ref: main
+          ref: ${{ inputs.dry_run && github.ref_name || 'main' }}
+          token: ${{ steps.release-token.outputs.token }}
+
+      - name: Validate release inputs
+        env:
+          VERSION: ${{ inputs.version }}
+          RELEASE_TITLE: ${{ inputs.release_title }}
+          RELEASE_DESCRIPTION: ${{ inputs.release_description }}
+        run: |
+          set -euo pipefail
+
+          if ! printf '%s' "$VERSION" | grep -Eq '^[0-9]+\.[0-9]+\.[0-9]+(-[0-9A-Za-z.-]+)?(\+[0-9A-Za-z.-]+)?$'; then
+            echo "::error::version must be SemVer without a leading v"
+            exit 1
+          fi
+
+          if [ -z "${RELEASE_TITLE//[[:space:]]/}" ] || [ "$RELEASE_TITLE" = "$VERSION" ] || [ "$RELEASE_TITLE" = "v$VERSION" ]; then
+            echo "::error::release_title must be natural prose, not just the version"
+            exit 1
+          fi
+
+          if [ -z "${RELEASE_DESCRIPTION//[[:space:]]/}" ]; then
+            echo "::error::release_description is required"
+            exit 1
+          fi
+
+          if git ls-remote --exit-code --tags origin "refs/tags/${VERSION}" >/dev/null 2>&1; then
+            echo "::error::tag refs/tags/${VERSION} already exists"
+            exit 1
+          fi
 
       - name: Setup Node.js
         uses: actions/setup-node@v4
@@ -36,38 +86,59 @@ jobs:
       - name: Install dependencies
         run: npm ci
 
-      - name: Set version
-        id: version
-        run: echo "version=${{ inputs.version }}" >> $GITHUB_OUTPUT
-
       - name: Convert README to HTML description
+        env:
+          REPO_RAW: https://raw.githubusercontent.com/${{ github.repository }}/main
         run: |
           npm install -g marked
-          REPO_RAW="https://raw.githubusercontent.com/${{ github.repository }}/main"
           cat README.md | \
             sed '/^\[!\[/d' | \
             sed "s|](docs/|](${REPO_RAW}/docs/|g" | \
             sed "s|src=\"docs/|src=\"${REPO_RAW}/docs/|g" \
             > readme_processed.md
           marked readme_processed.md > readme.html
-          sed -i '0,/<h1[^>]*>.*<\/h1>/s///' readme.html
+          sed -i '0,/^<h1[^>]*>.*<\/h1>$/d' readme.html
           cat readme.html | tr '\n' ' ' | sed 's/  */ /g' > readme_single.html
           rm -f readme_processed.md
 
-      - name: Update module.json version
+      - name: Prepare release metadata
+        id: prepare-release
+        env:
+          VERSION: ${{ inputs.version }}
+          RELEASE_TITLE: ${{ inputs.release_title }}
+          RELEASE_DESCRIPTION: ${{ inputs.release_description }}
+          MODULE_ID: ${{ env.MODULE_ID }}
+          REPO: ${{ github.repository }}
         run: |
-          VERSION=${{ steps.version.outputs.version }}
-          REPO_URL="https://github.com/${{ github.repository }}"
-          README_HTML=$(cat readme_single.html)
-          jq --arg ver "$VERSION" \
-             --arg manifest "${REPO_URL}/releases/download/${VERSION}/module.json" \
-             --arg download "${REPO_URL}/releases/download/${VERSION}/${MODULE_ID}.zip" \
-             --arg desc "$README_HTML" \
-             '.version = $ver | .manifest = $manifest | .download = $download | .description = $desc' \
-             module.json > module.json.tmp && mv module.json.tmp module.json
-          echo "Updated module.json:"
-          cat module.json | jq '.version, .manifest, .download'
-          rm -f readme.html readme_single.html
+          set -euo pipefail
+
+          node tools/release/prepare-release.mjs \
+            --version "${VERSION}" \
+            --release-title "${RELEASE_TITLE}" \
+            --release-description "${RELEASE_DESCRIPTION}" \
+            --module-id "${MODULE_ID}" \
+            --repo-url "https://github.com/${REPO}" \
+            --changelog-path CHANGELOG.md \
+            --module-json-path module.json \
+            --readme-html-path readme_single.html \
+            --release-body-path release_body.md \
+            --write \
+            --summary /tmp/prepare-release-plan.json
+
+          if [ ! -s release_body.md ]; then
+            echo "::error::Release body is empty after planning"
+            exit 1
+          fi
+
+          if ! grep -q "^## \\[${VERSION}\\]" CHANGELOG.md; then
+            echo "::error::CHANGELOG.md was not versioned for ${VERSION}"
+            exit 1
+          fi
+
+          if [ "$(jq -r '.version' module.json)" != "${VERSION}" ]; then
+            echo "::error::module.json version was not updated to ${VERSION}"
+            exit 1
+          fi
 
       - name: Build compendium packs
         run: npm run build:packs
@@ -90,73 +161,182 @@ jobs:
           cp ${{ env.MODULE_ID }}/module.json ../module.json.release
           cd ..
           mv module.json.release module.json
+          rm -f readme_single.html readme.html
 
-      - name: Generate changelog
-        id: changelog
+      - name: Resolve release bot identity
+        id: bot-user
+        env:
+          GH_TOKEN: ${{ steps.release-token.outputs.token }}
         run: |
-          VERSION=${{ steps.version.outputs.version }}
-          TODAY=$(date +%Y-%m-%d)
-          PREV_TAG=$(git describe --tags --abbrev=0 HEAD 2>/dev/null || echo "")
-          if [ -n "$PREV_TAG" ]; then
-            echo "Generating changelog from $PREV_TAG to HEAD"
-            COMMITS=$(git log --pretty=format:"- %s" $PREV_TAG..HEAD | grep -vE '^- (docs|ci|chore):')
-          else
-            echo "No previous tag found, including recent commits"
-            COMMITS=$(git log --pretty=format:"- %s" HEAD~10..HEAD 2>/dev/null || git log --pretty=format:"- %s" | grep -vE '^- (docs|ci|chore):')
-          fi
-          # Ensure we have at least something for the changelog
-          if [ -z "$COMMITS" ]; then
-            COMMITS="- Maintenance release"
-          fi
-          echo "$COMMITS" > changelog.txt
-          cat > new_entry.txt << 'ENTRY_EOF'
-          ## [$VERSION] - $TODAY
+          echo "user-id=$(gh api "/users/${{ steps.release-token.outputs.app-slug }}[bot]" --jq .id)" >> "$GITHUB_OUTPUT"
 
-          ### Changed
-          ENTRY_EOF
-          sed -i "s/\$VERSION/$VERSION/g; s/\$TODAY/$TODAY/g" new_entry.txt
-          echo "$COMMITS" >> new_entry.txt
-          head -n 7 CHANGELOG.md > CHANGELOG.tmp
-          echo "" >> CHANGELOG.tmp
-          cat new_entry.txt >> CHANGELOG.tmp
-          tail -n +8 CHANGELOG.md >> CHANGELOG.tmp
-          mv CHANGELOG.tmp CHANGELOG.md
-          rm new_entry.txt
-
-      - name: Commit CHANGELOG.md and create tag
+      - name: Plan atomic commit and tag payloads
+        id: github-plan
         run: |
-          VERSION=${{ steps.version.outputs.version }}
-          git config user.name "github-actions[bot]"
-          git config user.email "github-actions[bot]@users.noreply.github.com"
-          git add CHANGELOG.md
-          git commit -m "docs: update CHANGELOG.md for ${VERSION}" || echo "No changes to commit"
-          git tag -a "${VERSION}" -m "Release ${VERSION}"
-          git push origin main
-          git push origin "${VERSION}"
+          node tools/release/plan-github-update.mjs \
+            --repo "${{ github.repository }}" \
+            --version "${{ inputs.version }}" \
+            --commit-message "docs(release): release ${{ inputs.version }} [skip ci]" \
+            --actor-name "${{ steps.release-token.outputs.app-slug }}[bot]" \
+            --actor-email "${{ steps.bot-user.outputs.user-id }}+${{ steps.release-token.outputs.app-slug }}[bot]@users.noreply.github.com" \
+            --file module.json \
+            --file CHANGELOG.md \
+            --base-commit "$(git rev-parse HEAD)" \
+            --base-tree "$(git rev-parse HEAD^{tree})" \
+            --include-tag \
+            --output /tmp/github-plan.json
+
+      - name: Create release Git database commit and tag
+        if: inputs.dry_run == false
+        env:
+          GH_TOKEN: ${{ steps.release-token.outputs.token }}
+        run: |
+          set -euo pipefail
+          VERSION="${{ inputs.version }}"
+          REPO="${{ github.repository }}"
+          COMMIT_MESSAGE="docs(release): release ${VERSION} [skip ci]"
+          BOT_NAME="${{ steps.release-token.outputs.app-slug }}[bot]"
+          BOT_EMAIL="${{ steps.bot-user.outputs.user-id }}+${{ steps.release-token.outputs.app-slug }}[bot]@users.noreply.github.com"
+
+          if git ls-remote --exit-code --tags origin "refs/tags/${VERSION}" >/dev/null 2>&1; then
+            echo "::error::tag refs/tags/${VERSION} already exists"
+            exit 1
+          fi
+
+          FILES_TO_COMMIT=()
+          if ! git diff --quiet -- CHANGELOG.md; then
+            FILES_TO_COMMIT+=("CHANGELOG.md")
+          fi
+          if ! git diff --quiet -- module.json; then
+            FILES_TO_COMMIT+=("module.json")
+          fi
+
+          if [ "${#FILES_TO_COMMIT[@]}" -eq 0 ]; then
+            echo "::error::No release file changes to commit"
+            exit 1
+          fi
+
+          BASE_COMMIT_SHA=$(git rev-parse HEAD)
+          BASE_TREE_SHA=$(git rev-parse "${BASE_COMMIT_SHA}^{tree}")
+          TREE_ENTRIES='[]'
+
+          for file in "${FILES_TO_COMMIT[@]}"; do
+            if [ ! -f "$file" ]; then
+              echo "::error::Missing expected file: $file"
+              exit 1
+            fi
+            BLOB_BODY=$(mktemp)
+            jq -n \
+              --arg content "$(base64 -w 0 "$file")" \
+              '{content: $content, encoding: "base64"}' > "$BLOB_BODY"
+            BLOBSHA=$(gh api "/repos/${REPO}/git/blobs" \
+              --method POST \
+              --input "$BLOB_BODY" \
+              --jq .sha)
+            ENTRY=$(jq -n \
+              --arg path "$file" \
+              --arg sha "$BLOBSHA" \
+              '{path: $path, mode: "100644", type: "blob", sha: $sha}')
+            TREE_ENTRIES=$(echo "$TREE_ENTRIES" | jq -c ". + [$ENTRY]")
+          done
+
+          jq -n \
+            --arg base_tree "$BASE_TREE_SHA" \
+            --argjson tree "$TREE_ENTRIES" \
+            '{base_tree: $base_tree, tree: $tree}' > /tmp/release-tree.json
+
+          TREE_SHA=$(gh api "/repos/${REPO}/git/trees" \
+            --method POST \
+            --input /tmp/release-tree.json \
+            --jq .sha)
+
+          jq -n \
+            --arg message "$COMMIT_MESSAGE" \
+            --arg tree "$TREE_SHA" \
+            --arg parent "$BASE_COMMIT_SHA" \
+            --arg name "$BOT_NAME" \
+            --arg email "$BOT_EMAIL" \
+            '{
+              message: $message,
+              tree: $tree,
+              parents: [$parent],
+              author: {name: $name, email: $email},
+              committer: {name: $name, email: $email}
+            }' > /tmp/release-commit.json
+
+          RELEASE_COMMIT_SHA=$(gh api "/repos/${REPO}/git/commits" \
+            --method POST \
+            --input /tmp/release-commit.json \
+            --jq .sha)
+
+          jq -n --arg sha "$RELEASE_COMMIT_SHA" '{sha: $sha, force: false}' > /tmp/release-ref.json
+          gh api "/repos/${REPO}/git/refs/heads/main" \
+            --method PATCH \
+            --input /tmp/release-ref.json \
+            --silent
+
+          jq -n \
+            --arg tag "$VERSION" \
+            --arg message "Release ${VERSION}" \
+            --arg object "$RELEASE_COMMIT_SHA" \
+            --arg type "commit" \
+            --arg name "$BOT_NAME" \
+            --arg email "$BOT_EMAIL" \
+            --arg date "$(date -u +%Y-%m-%dT%H:%M:%SZ)" \
+            '{
+              tag: $tag,
+              message: $message,
+              object: $object,
+              type: $type,
+              tagger: {name: $name, email: $email, date: $date}
+            }' > /tmp/release-tag-object.json
+
+          TAG_SHA=$(gh api "/repos/${REPO}/git/tags" \
+            --method POST \
+            --input /tmp/release-tag-object.json \
+            --jq .sha)
+
+          jq -n \
+            --arg ref "refs/tags/${VERSION}" \
+            --arg sha "$TAG_SHA" \
+            '{ref: $ref, sha: $sha}' > /tmp/release-tag-ref.json
+          gh api "/repos/${REPO}/git/refs" \
+            --method POST \
+            --input /tmp/release-tag-ref.json \
+            --silent
+
+          echo "release_commit_sha=$RELEASE_COMMIT_SHA" >> "$GITHUB_OUTPUT"
+
+      - name: Show planned API payloads (dry run)
+        if: inputs.dry_run == true
+        run: |
+          echo "Planned payload for module/release commit and tag:"
+          cat /tmp/github-plan.json
 
       - name: Create GitHub Release
+        if: inputs.dry_run == false
         uses: softprops/action-gh-release@v1
         with:
-          tag_name: ${{ steps.version.outputs.version }}
-          name: "v${{ steps.version.outputs.version }}"
-          body_path: changelog.txt
+          tag_name: ${{ inputs.version }}
+          name: ${{ inputs.release_title }}
+          body_path: release_body.md
           files: |
             module.json
             ${{ env.MODULE_ID }}.zip
           fail_on_unmatched_files: true
         env:
-          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+          GITHUB_TOKEN: ${{ steps.release-token.outputs.token }}
 
       - name: Publish to Foundry VTT
+        if: inputs.dry_run == false
         env:
           FVTT_TOKEN: ${{ secrets.FOUNDRY_RELEASE_TOKEN }}
         run: |
           OUTPUT=$(npx @ghost-fvtt/foundry-publish \
             --manifestPath module.json \
-            --manifestURL "https://github.com/${{ github.repository }}/releases/download/${{ steps.version.outputs.version }}/module.json" 2>&1) || {
+            --manifestURL "https://github.com/${{ github.repository }}/releases/download/${{ inputs.version }}/module.json" 2>&1) || {
             if echo "$OUTPUT" | grep -q "already exists"; then
               echo "Version already published to Foundry VTT, skipping"
-              exit 0
             else
               echo "$OUTPUT"
               exit 1
@@ -164,6 +344,7 @@ jobs:
           }
 
       - name: Announce on Discord
+        if: inputs.dry_run == false
         env:
           DISCORD_WEBHOOK_URL: ${{ secrets.DISCORD_WEBHOOK_URL }}
         run: |
@@ -171,24 +352,29 @@ jobs:
             echo "Discord webhook not configured, skipping announcement"
             exit 0
           fi
-          VERSION=${{ steps.version.outputs.version }}
+
+          VERSION="${{ inputs.version }}"
           REPO_URL="https://github.com/${{ github.repository }}"
           RELEASE_URL="${REPO_URL}/releases/tag/${VERSION}"
-          # Discord field value limit is 1024 chars - truncate by lines until under limit
           SUFFIX=$'\n'"[See full release notes](${RELEASE_URL})"
-          MAX_CHARS=$((1024 - ${#SUFFIX} - 10))
-          CHANGELOG=$(cat changelog.txt)
+          MAX_CHARS=$((1024 - ${#SUFFIX}))
+          CHANGELOG_FILE=changelog.txt
+          awk -v version="$VERSION" '
+            $0 == "## [" version "]" || index($0, "## [" version "] - ") == 1 { found=1; next }
+            found && /^## \\[/ { exit }
+            found { print }
+          ' CHANGELOG.md > "$CHANGELOG_FILE"
+          CHANGELOG=$(cat "$CHANGELOG_FILE")
+          if [ -z "$CHANGELOG" ]; then
+            CHANGELOG="Release ${VERSION}"
+          fi
           while [ ${#CHANGELOG} -gt $MAX_CHARS ]; do
-            # Drop the last line and append truncation notice
             CHANGELOG=$(echo "$CHANGELOG" | head -n -1)
           done
-          if [ ${#CHANGELOG} -lt $(wc -c < changelog.txt) ]; then
-            CHANGELOG="${CHANGELOG}${SUFFIX}"
-          fi
+          CHANGELOG="${CHANGELOG}${SUFFIX}"
 
-          # Build JSON payload with proper escaping using jq
           PAYLOAD=$(jq -n \
-            --arg title "Simulacrum v${VERSION} Released!" \
+            --arg title "Simulacrum ${VERSION} Released!" \
             --arg url "$RELEASE_URL" \
             --arg desc "A new version of Simulacrum: AI Campaign Copilot is now available!" \
             --arg changes "$CHANGELOG" \
@@ -207,11 +393,14 @@ jobs:
               }]
             }')
 
-          echo "Payload: $PAYLOAD"
-          HTTP_CODE=$(curl -s -o /tmp/discord_response.txt -w "%{http_code}" -H "Content-Type: application/json" -X POST -d "$PAYLOAD" "$DISCORD_WEBHOOK_URL")
+          HTTP_CODE=$(curl -s -o /tmp/discord_response.txt -w "%{http_code}" \
+            -H "Content-Type: application/json" \
+            -X POST \
+            -d "$PAYLOAD" \
+            "$DISCORD_WEBHOOK_URL")
           BODY=$(cat /tmp/discord_response.txt)
-          echo "Response ($HTTP_CODE): $BODY"
           if [ "$HTTP_CODE" -lt 200 ] || [ "$HTTP_CODE" -ge 300 ]; then
             echo "::error::Discord announcement failed with HTTP $HTTP_CODE"
+            echo "Response: $BODY"
             exit 1
           fi

--- a/.github/workflows/create-release.yml
+++ b/.github/workflows/create-release.yml
@@ -57,7 +57,7 @@ jobs:
         run: |
           set -euo pipefail
 
-          if ! printf '%s' "$VERSION" | grep -Eq '^[0-9]+\.[0-9]+\.[0-9]+(-[0-9A-Za-z.-]+)?(\+[0-9A-Za-z.-]+)?$'; then
+          if ! [[ "$VERSION" =~ ^[0-9]+\.[0-9]+\.[0-9]+(-[0-9A-Za-z.-]+)?(\+[0-9A-Za-z.-]+)?$ ]]; then
             echo "::error::version must be SemVer without a leading v"
             exit 1
           fi

--- a/.github/workflows/create-release.yml
+++ b/.github/workflows/create-release.yml
@@ -43,7 +43,7 @@ jobs:
           permission-contents: write
 
       - name: Checkout
-        uses: actions/checkout@v4
+        uses: actions/checkout@v6
         with:
           fetch-depth: 0
           ref: ${{ inputs.dry_run && github.ref_name || 'main' }}
@@ -78,9 +78,9 @@ jobs:
           fi
 
       - name: Setup Node.js
-        uses: actions/setup-node@v4
+        uses: actions/setup-node@v6
         with:
-          node-version: '20'
+          node-version: '24'
           cache: 'npm'
 
       - name: Install dependencies
@@ -315,7 +315,7 @@ jobs:
 
       - name: Create GitHub Release
         if: inputs.dry_run == false
-        uses: softprops/action-gh-release@v1
+        uses: softprops/action-gh-release@v3
         with:
           tag_name: ${{ inputs.version }}
           name: ${{ inputs.release_title }}

--- a/.github/workflows/update-changelog.yml
+++ b/.github/workflows/update-changelog.yml
@@ -1,0 +1,162 @@
+# Post-merge changelog auto-update
+# Generates/updates an [Unreleased] section after every merge to main.
+
+name: Update Changelog
+
+on:
+  push:
+    branches:
+      - main
+  workflow_dispatch:
+    inputs:
+      dry_run:
+        description: 'Plan changes only (no remote mutation)'
+        required: false
+        type: boolean
+        default: true
+
+jobs:
+  update-changelog:
+    runs-on: ubuntu-latest
+    permissions:
+      contents: write
+    if: >-
+      github.event_name != 'push' ||
+      (
+        !startsWith(github.event.head_commit.message, 'docs(release):') &&
+        !startsWith(github.event.head_commit.message, 'docs: update unreleased changelog') &&
+        !contains(github.event.head_commit.message, '[skip ci]')
+      )
+    steps:
+      - name: Generate release bot token
+        id: release-token
+        uses: actions/create-github-app-token@v3
+        with:
+          client-id: ${{ vars.RELEASE_APP_CLIENT_ID }}
+          private-key: ${{ secrets.RELEASE_APP_PRIVATE_KEY }}
+          permission-contents: write
+
+      - name: Checkout
+        uses: actions/checkout@v4
+        with:
+          fetch-depth: 0
+          ref: main
+          token: ${{ steps.release-token.outputs.token }}
+          persist-credentials: true
+
+      - name: Resolve release bot identity
+        id: bot-user
+        env:
+          GH_TOKEN: ${{ steps.release-token.outputs.token }}
+        run: |
+          echo "user-id=$(gh api "/users/${{ steps.release-token.outputs.app-slug }}[bot]" --jq .id)" >> "$GITHUB_OUTPUT"
+
+      - name: Resolve runtime mode
+        id: runtime
+        run: |
+          if [ "${{ github.event_name }}" = "workflow_dispatch" ] && [ "${{ inputs.dry_run }}" = "true" ]; then
+            echo "dry_run=true" >> "$GITHUB_OUTPUT"
+          else
+            echo "dry_run=false" >> "$GITHUB_OUTPUT"
+          fi
+
+      - name: Generate unreleased changelog
+        id: changelog
+        run: |
+          if [ "${{ steps.runtime.outputs.dry_run }}" = "true" ]; then
+            MODE_ARGS="--dry-run"
+          else
+            MODE_ARGS="--write"
+          fi
+
+          node tools/release/generate-unreleased-changelog.mjs \
+            --changelog-path CHANGELOG.md \
+            $MODE_ARGS \
+            --summary /tmp/generate-changelog.json
+
+          HAS_UPDATES=$(jq -r .hasUpdates /tmp/generate-changelog.json)
+          echo "has_updates=$HAS_UPDATES" >> "$GITHUB_OUTPUT"
+
+      - name: Plan changelog commit payload
+        if: steps.changelog.outputs.has_updates == 'true'
+        run: |
+          node tools/release/plan-github-update.mjs \
+            --repo "${{ github.repository }}" \
+            --version "changelog-${{ github.sha }}" \
+            --commit-message "docs: update unreleased changelog [skip ci]" \
+            --actor-name "${{ steps.release-token.outputs.app-slug }}[bot]" \
+            --actor-email "${{ steps.bot-user.outputs.user-id }}+${{ steps.release-token.outputs.app-slug }}[bot]@users.noreply.github.com" \
+            --base-commit "$(git rev-parse HEAD)" \
+            --base-tree "$(git rev-parse HEAD^{tree})" \
+            --file CHANGELOG.md \
+            --output /tmp/changelog-github-plan.json
+
+      - name: Commit unreleased changelog via Git database API
+        if: steps.changelog.outputs.has_updates == 'true' && steps.runtime.outputs.dry_run != 'true'
+        env:
+          GH_TOKEN: ${{ steps.release-token.outputs.token }}
+        run: |
+          set -euo pipefail
+          REPO="${{ github.repository }}"
+          COMMIT_MESSAGE="docs: update unreleased changelog [skip ci]"
+          BOT_NAME="${{ steps.release-token.outputs.app-slug }}[bot]"
+          BOT_EMAIL="${{ steps.bot-user.outputs.user-id }}+${{ steps.release-token.outputs.app-slug }}[bot]@users.noreply.github.com"
+
+          if git diff --quiet CHANGELOG.md; then
+            echo "No changelog changes to commit"
+            exit 0
+          fi
+
+          BASE_COMMIT_SHA=$(git rev-parse HEAD)
+          BASE_TREE_SHA=$(git rev-parse "${BASE_COMMIT_SHA}^{tree}")
+
+          BLOB_BODY=$(mktemp)
+          jq -n \
+            --arg content "$(base64 -w 0 CHANGELOG.md)" \
+            '{content: $content, encoding: "base64"}' > "$BLOB_BODY"
+
+          BLOBSHA=$(gh api "/repos/${REPO}/git/blobs" \
+            --method POST \
+            --input "$BLOB_BODY" \
+            --jq .sha)
+
+          jq -n \
+            --arg base_tree "$BASE_TREE_SHA" \
+            --arg path "CHANGELOG.md" \
+            --arg sha "$BLOBSHA" \
+            '{base_tree: $base_tree, tree: [{path: $path, mode: "100644", type: "blob", sha: $sha}]}' \
+            > /tmp/changelog-tree.json
+
+          TREE_SHA=$(gh api "/repos/${REPO}/git/trees" \
+            --method POST \
+            --input /tmp/changelog-tree.json \
+            --jq .sha)
+
+          jq -n \
+            --arg message "$COMMIT_MESSAGE" \
+            --arg tree "$TREE_SHA" \
+            --arg parent "$BASE_COMMIT_SHA" \
+            --arg name "$BOT_NAME" \
+            --arg email "$BOT_EMAIL" \
+            '{
+              message: $message,
+              tree: $tree,
+              parents: [$parent],
+              author: {name: $name, email: $email},
+              committer: {name: $name, email: $email}
+            }' > /tmp/changelog-commit.json
+
+          CHANGES_SHA=$(gh api "/repos/${REPO}/git/commits" \
+            --method POST \
+            --input /tmp/changelog-commit.json \
+            --jq .sha)
+
+          jq -n --arg sha "$CHANGES_SHA" '{sha: $sha, force: false}' > /tmp/changelog-ref.json
+          gh api "/repos/${REPO}/git/refs/heads/main" \
+            --method PATCH \
+            --input /tmp/changelog-ref.json \
+            --silent
+
+      - name: Show planned changelog payload (dry run)
+        if: steps.changelog.outputs.has_updates == 'true' && steps.runtime.outputs.dry_run == 'true'
+        run: cat /tmp/changelog-github-plan.json

--- a/.github/workflows/update-changelog.yml
+++ b/.github/workflows/update-changelog.yml
@@ -37,7 +37,7 @@ jobs:
           permission-contents: write
 
       - name: Checkout
-        uses: actions/checkout@v4
+        uses: actions/checkout@v6
         with:
           fetch-depth: 0
           ref: main

--- a/.github/workflows/update-changelog.yml
+++ b/.github/workflows/update-changelog.yml
@@ -40,7 +40,7 @@ jobs:
         uses: actions/checkout@v6
         with:
           fetch-depth: 0
-          ref: main
+          ref: ${{ inputs.dry_run && github.ref_name || 'main' }}
           token: ${{ steps.release-token.outputs.token }}
           persist-credentials: true
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,10 +5,20 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [Unreleased] - 2026-06-19
+
+### Fixed
+
+- Fix Foundry v14 sidebar rendering regression
+- ui: prevent race condition cascade on message cancellation
+- core: fix context compaction overflow and context limit honoring (Fixes #150)
+- core: ensure outgoing tool call arguments are valid JSON (Fixes #145)
+- persist hasEverIndexed flag to unblock search_assets on reload (#126)
 
 ## [1.0.9] - 2026-03-18
 
 ### Changed
+
 - refactor: remove maxResults caps and merge compendium management into document tools
 - feat: add document copy and move tools
 - feat: add compendium create action and rename pack_id to packId
@@ -22,6 +32,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ## [1.0.8] - 2026-02-08
 
 ### Changed
+
 - refactor(benchmark): replace webhook with guided Discord sharing flow
 - chore(benchmark): switch webhook to public channel, drop review language
 - fix(benchmark): note that Discord submissions are reviewed
@@ -53,14 +64,16 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ## [1.0.7] - 2026-02-06
 
 ### Changed
+
 - fix: Ollama integration - race conditions, non-blocking validation, token limit consolidation
 - fix(ci): Fix shell quoting in Discord announcement step
 
 ## [1.0.6] - 2026-02-05
 
 ### Changed
+
 - fix(ui): Restore status bar styling and task tracker regressions
-- fix(ui): Remove leftover _monitorStatus call causing crash
+- fix(ui): Remove leftover \_monitorStatus call causing crash
 - fix(ui): Restore status bar and indexing status logic
 - feat: Add context limit handling and sidebar UI refinements
 - fix: restore tool justification expand/collapse functionality
@@ -75,6 +88,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ## [1.0.5] - 2026-02-03
 
 ### Changed
+
 - fix: preserve textarea content and status area on thinking state change
 - fix: extract proper content summary for direct display tools
 - fix: prevent raw JSON from rendering for direct display tools
@@ -91,6 +105,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ## [1.0.4] - 2026-02-03
 
 ### Changed
+
 - fix: make disabled sidebar tab properly inert and V12 compatibility
 - style: refine Discord link appearance in settings
 - fix: add Discord link to Foundry settings config, remove dead code
@@ -103,11 +118,13 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ## [1.0.3] - 2026-01-31
 
 ### Changed
+
 - fix: restore system-agnostic CSS for Carolingian UX compatibility
 
 ## [1.0.2] - 2026-01-31
 
 ### Changed
+
 - ci: switch to manual workflow_dispatch for releases
 - docs: add CONTRIBUTING.md with commit conventions
 - fix: correct content/display pattern in list_documents tool
@@ -135,9 +152,11 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - fix: prevent context overflow from large tool outputs
 - fix: remove oneOf from execute_macro schema for Anthropic compatibility
 - feat: auto-update CHANGELOG.md on release
+
 ## [1.0.0] - 2026-01-12
 
 ### Added
+
 - Initial public release of Simulacrum: AI Campaign Copilot
 - Natural language document management (create, read, update, delete)
 - Multi-provider AI support (OpenAI, Google Gemini, Anthropic, and OpenAI-compatible APIs)

--- a/tools/release/generate-unreleased-changelog.mjs
+++ b/tools/release/generate-unreleased-changelog.mjs
@@ -224,7 +224,7 @@ function changedFilesForCommit(sha) {
   const parentCount = parentLine ? parentLine.split(/\s+/).length - 1 : 0;
   const command =
     parentCount > 1
-      ? `git diff --name-only ${sha}^1 ${sha}`
+      ? `git diff --name-only ${sha}~1 ${sha}`
       : `git show --name-only --pretty=format: --no-renames ${sha}`;
   return runGitLog(command, options.repoRoot)
     .split('\n')

--- a/tools/release/generate-unreleased-changelog.mjs
+++ b/tools/release/generate-unreleased-changelog.mjs
@@ -6,6 +6,7 @@ import fs from 'node:fs';
 const args = parseArgs(process.argv.slice(2));
 const optionAliases = {
   changelog: 'changelogPath',
+  summary: 'summaryPath',
 };
 
 const options = {

--- a/tools/release/generate-unreleased-changelog.mjs
+++ b/tools/release/generate-unreleased-changelog.mjs
@@ -1,0 +1,337 @@
+#!/usr/bin/env node
+/* eslint-disable no-console */
+import { execSync } from 'node:child_process';
+import fs from 'node:fs';
+
+const args = parseArgs(process.argv.slice(2));
+const optionAliases = {
+  changelog: 'changelogPath',
+};
+
+const options = {
+  changelogPath: 'CHANGELOG.md',
+  repoRoot: process.cwd(),
+  dryRun: false,
+  writeFile: false,
+  includePaths: [
+    'scripts',
+    'styles',
+    'templates',
+    'lang',
+    'assets',
+    'packs',
+    'module.json',
+    'README.md',
+  ],
+  summaryPath: '',
+};
+
+for (const [key, value] of Object.entries(args)) {
+  const optionKey = optionAliases[key] || key;
+  if (Object.hasOwn(options, optionKey)) {
+    options[optionKey] = value;
+  }
+}
+
+const changelog = readText(options.changelogPath);
+const includePaths = options.includePaths.map(entry => entry.replace(/\/+$/, ''));
+const skipMessagePatterns = [
+  /^docs\(release\):/i,
+  /^docs:\s*update unreleased changelog/i,
+  /\[skip ci\]/i,
+];
+
+const latestTag = resolveLatestReleaseTag();
+const range = latestTag ? `${latestTag}..HEAD` : '';
+const commits = runGitLog(`git log --first-parent --pretty=format:%H ${range}`, options.repoRoot)
+  .split('\n')
+  .map(sha => sha.trim())
+  .filter(Boolean)
+  .map(sha => {
+    const subject = runGitLog(`git show -s --format=%s ${sha}`, options.repoRoot).trim();
+    const body = runGitLog(`git show -s --format=%b ${sha}`, options.repoRoot).trim();
+    return { sha, subject, body, releaseSubject: releaseSubjectForCommit(subject, body) };
+  })
+  .filter(entry => entry.sha && entry.releaseSubject);
+
+const grouped = {
+  Added: [],
+  Changed: [],
+  Fixed: [],
+  Deprecated: [],
+  Removed: [],
+  Security: [],
+  Documentation: [],
+  Testing: [],
+  'CI/CD': [],
+  Build: [],
+  Other: [],
+};
+const headingOrder = Object.keys(grouped);
+
+for (const commit of commits) {
+  if (
+    skipMessagePatterns.some(
+      pattern => pattern.test(commit.subject) || pattern.test(commit.releaseSubject)
+    )
+  ) {
+    continue;
+  }
+
+  const changedFiles = changedFilesForCommit(commit.sha);
+
+  const hasRelevantChange = changedFiles.some(filePath =>
+    isRelevantProductPath(filePath, includePaths)
+  );
+  if (!hasRelevantChange) {
+    continue;
+  }
+
+  const parsed = /^([a-z]+)(\([^)]+\))?:\s*(.*)$/i.exec(commit.releaseSubject);
+  const rawType = parsed ? parsed[1].toLowerCase() : 'other';
+  const scope = parsed?.[2] ? `${parsed[2].slice(1, -1)}: ` : '';
+  const message = (parsed?.[3] || commit.releaseSubject).trim() || 'chore: change';
+  const section = parsed ? sectionForType(rawType) : sectionForFreeformSubject(message);
+  const entry = `${scope}${message}`;
+  if (!grouped[section].includes(entry)) {
+    grouped[section].push(entry);
+  }
+}
+
+const hasUpdates = Object.values(grouped).some(entries => entries.length > 0);
+const releaseDate = new Date().toISOString().slice(0, 10);
+const newSection = hasUpdates
+  ? generateSection(releaseDate, grouped, headingOrder)
+  : `## [Unreleased] - ${releaseDate}\n`;
+
+let nextChangelog = changelog;
+
+if (hasUpdates) {
+  const existingUnreleased = findUnreleasedSection(changelog);
+  if (existingUnreleased) {
+    nextChangelog = [
+      changelog.slice(0, existingUnreleased.start),
+      newSection.trimEnd(),
+      '\n\n',
+      changelog.slice(existingUnreleased.end).replace(/^\n+/, ''),
+    ].join('');
+  } else {
+    const insertionPoint = changelog.indexOf('\n## [');
+    if (insertionPoint === -1) {
+      nextChangelog = `${changelog.trimEnd()}\n\n${newSection}\n`;
+    } else {
+      nextChangelog = `${changelog.slice(0, insertionPoint + 1)}${newSection}\n${changelog.slice(insertionPoint + 1)}`;
+    }
+  }
+}
+
+if (options.writeFile && hasUpdates) {
+  fs.writeFileSync(options.changelogPath, nextChangelog);
+}
+
+const summary = {
+  changelogPath: options.changelogPath,
+  generatedAt: new Date().toISOString(),
+  latestReleaseTag: latestTag,
+  hasUpdates,
+  dryRun: options.dryRun || !options.writeFile,
+  writeFile: options.writeFile,
+  headingOrder,
+  entryCount: Object.values(grouped).reduce((count, entries) => count + entries.length, 0),
+  sectionLines: newSection.trim(),
+};
+
+if (options.summaryPath) {
+  fs.writeFileSync(options.summaryPath, `${JSON.stringify(summary, null, 2)}\n`);
+}
+
+console.log(JSON.stringify(summary, null, 2));
+
+if (options.writeFile && !hasUpdates) {
+  console.log('{"hasUpdates": false, "message": "No product-facing commits found"}');
+}
+
+function runGitLog(command, cwd) {
+  try {
+    return execSync(command, {
+      cwd,
+      encoding: 'utf8',
+      stdio: ['pipe', 'pipe', 'ignore'],
+    });
+  } catch (error) {
+    return '';
+  }
+}
+
+function sectionForType(type) {
+  const map = {
+    feat: 'Added',
+    feature: 'Added',
+    add: 'Added',
+    fix: 'Fixed',
+    fixed: 'Fixed',
+    bug: 'Fixed',
+    bugfix: 'Fixed',
+    chore: 'Changed',
+    change: 'Changed',
+    changed: 'Changed',
+    refactor: 'Changed',
+    perf: 'Changed',
+    build: 'Build',
+    ci: 'CI/CD',
+    test: 'Testing',
+    tests: 'Testing',
+    docs: 'Documentation',
+    doc: 'Documentation',
+    deprecated: 'Deprecated',
+    removed: 'Removed',
+    security: 'Security',
+  };
+  return map[type] || 'Other';
+}
+
+function sectionForFreeformSubject(subject) {
+  if (/^(fix|fixed|resolve|resolved|prevent|repair)\b/i.test(subject)) {
+    return 'Fixed';
+  }
+  if (/^(add|added|support|enable)\b/i.test(subject)) {
+    return 'Added';
+  }
+  if (/^(remove|removed|drop)\b/i.test(subject)) {
+    return 'Removed';
+  }
+  if (/^(secure|security)\b/i.test(subject)) {
+    return 'Security';
+  }
+  return 'Changed';
+}
+
+function releaseSubjectForCommit(subject, body) {
+  if (/^Merge pull request #\d+ from /i.test(subject)) {
+    const bodyTitle = body
+      .split('\n')
+      .map(line => line.trim())
+      .find(Boolean);
+    if (bodyTitle) {
+      return bodyTitle;
+    }
+  }
+  return subject;
+}
+
+function changedFilesForCommit(sha) {
+  const parentLine = runGitLog(`git rev-list --parents -n 1 ${sha}`, options.repoRoot).trim();
+  const parentCount = parentLine ? parentLine.split(/\s+/).length - 1 : 0;
+  const command =
+    parentCount > 1
+      ? `git diff --name-only ${sha}^1 ${sha}`
+      : `git show --name-only --pretty=format: --no-renames ${sha}`;
+  return runGitLog(command, options.repoRoot)
+    .split('\n')
+    .map(filePath => filePath.trim())
+    .filter(Boolean);
+}
+
+function isRelevantProductPath(filePath, includePaths) {
+  if (
+    !filePath ||
+    filePath.startsWith('.github/') ||
+    filePath.startsWith('.git/') ||
+    filePath.startsWith('tests/') ||
+    filePath.includes('CHANGELOG.md') ||
+    filePath === 'package.json' ||
+    filePath === 'package-lock.json'
+  ) {
+    return false;
+  }
+  return includePaths.some(targetPath => {
+    const normalizedTarget = targetPath.replace(/\/+$/, '');
+    return filePath === normalizedTarget || filePath.startsWith(`${normalizedTarget}/`);
+  });
+}
+
+function findUnreleasedSection(content) {
+  const headingMatch = /^## \[Unreleased\][^\n]*$/m.exec(content);
+  if (!headingMatch) {
+    return null;
+  }
+  const start = headingMatch.index;
+  const nextSearchStart = start + headingMatch[0].length + 1;
+  const nextHeadingMatch = /^## \[/m.exec(content.slice(nextSearchStart));
+  const end = nextHeadingMatch ? nextSearchStart + nextHeadingMatch.index : content.length;
+  return {
+    start,
+    end,
+    text: content.slice(start, end),
+  };
+}
+
+function generateSection(releaseDate, grouped, headingOrder) {
+  const lines = [`## [Unreleased] - ${releaseDate}`, ''];
+  for (const heading of headingOrder) {
+    const entries = grouped[heading];
+    if (!entries.length) {
+      continue;
+    }
+    lines.push(`### ${heading}`, '');
+    for (const entry of entries) {
+      lines.push(`- ${entry}`);
+    }
+    lines.push('');
+  }
+  return `${lines.join('\n')}\n`;
+}
+
+function resolveLatestReleaseTag() {
+  return (
+    runGitLog('git tag --sort=-version:refname', options.repoRoot)
+      .split('\n')
+      .map(tag => tag.trim())
+      .filter(Boolean)
+      .find(tag => /^v?\d+\.\d+\.\d+/.test(tag)) || ''
+  );
+}
+
+function parseArgs(rawArgs) {
+  const values = {};
+  for (let i = 0; i < rawArgs.length; i += 1) {
+    const arg = rawArgs[i];
+    if (!arg.startsWith('--')) {
+      continue;
+    }
+    if (arg === '--dry-run') {
+      values.dryRun = true;
+      continue;
+    }
+    if (arg === '--write') {
+      values.writeFile = true;
+      continue;
+    }
+    const key = toCamelCase(arg.replace(/^--/, ''));
+    const next = rawArgs[i + 1];
+    if (next === undefined || next.startsWith('--')) {
+      continue;
+    }
+    values[key] = next;
+    i += 1;
+  }
+  return values;
+}
+
+function readText(filePath) {
+  try {
+    return fs.readFileSync(filePath, 'utf8');
+  } catch (error) {
+    console.error(`Unable to read ${filePath}: ${error.message}`);
+    process.exit(1);
+  }
+}
+
+function toCamelCase(value) {
+  return value
+    .split('-')
+    .map((segment, index) =>
+      index === 0 ? segment : segment.charAt(0).toUpperCase() + segment.slice(1)
+    )
+    .join('');
+}

--- a/tools/release/plan-github-update.mjs
+++ b/tools/release/plan-github-update.mjs
@@ -1,0 +1,191 @@
+#!/usr/bin/env node
+/* eslint-disable no-console */
+import fs from 'node:fs';
+
+const args = parseArgs(process.argv.slice(2));
+
+const options = {
+  repo: '',
+  branch: 'main',
+  version: '',
+  commitMessage: '',
+  actorName: 'simulacrum-release[bot]',
+  actorEmail: 'simulacrum-release[bot]@users.noreply.github.com',
+  baseCommit: '',
+  baseTree: '',
+  files: [],
+  includeTag: false,
+  output: '',
+};
+
+for (const [key, value] of Object.entries(args)) {
+  if (Object.hasOwn(options, key)) {
+    if (key === 'files') {
+      options.files = value;
+      continue;
+    }
+    options[key] = value;
+  }
+}
+
+if (!options.repo || !options.version || !options.commitMessage || options.files.length === 0) {
+  console.error('repo, version, commitMessage, and files are required');
+  process.exit(1);
+}
+if (!options.baseCommit || !options.baseTree) {
+  console.error('base-commit and base-tree are required');
+  process.exit(1);
+}
+
+const entries = options.files.map(filePath => {
+  const content = fs.readFileSync(filePath, 'utf8');
+  const base64 = Buffer.from(content).toString('base64');
+  return {
+    path: filePath,
+    contentBase64: base64,
+    blobRequestBody: {
+      content: base64,
+      encoding: 'base64',
+    },
+  };
+});
+
+const normalizedRepo = options.repo.replace(/^github\.com\//, '');
+const treePayload = {
+  base_tree: options.baseTree,
+  tree: entries.map(entry => ({
+    path: entry.path,
+    mode: '100644',
+    type: 'blob',
+    sha: `<blob_sha:${entry.path}>`,
+  })),
+};
+
+const commitPayload = {
+  message: options.commitMessage,
+  tree: '<TREE_SHA_PLACEHOLDER>',
+  parents: [options.baseCommit],
+  author: { name: options.actorName, email: options.actorEmail },
+  committer: { name: options.actorName, email: options.actorEmail },
+};
+
+const tagPayload = {
+  tag: options.version,
+  message: `Release ${options.version}`,
+  object: '<RELEASE_COMMIT_SHA_PLACEHOLDER>',
+  type: 'commit',
+  tagger: {
+    name: options.actorName,
+    email: options.actorEmail,
+    date: new Date().toISOString(),
+  },
+};
+
+const plan = {
+  repository: normalizedRepo,
+  branch: `refs/heads/${options.branch}`,
+  baseCommit: options.baseCommit,
+  baseTree: options.baseTree,
+  atomicCommit: {
+    blobEndpoint: `/repos/${normalizedRepo}/git/blobs`,
+    commitEndpoint: `/repos/${normalizedRepo}/git/commits`,
+    refEndpoint: `/repos/${normalizedRepo}/git/refs/heads/${options.branch}`,
+    treePayloadEndpoint: `/repos/${normalizedRepo}/git/trees`,
+    blobRequests: entries.map(entry => ({
+      path: entry.path,
+      method: 'POST',
+      body: entry.blobRequestBody,
+    })),
+    treeRequest: {
+      method: 'POST',
+      body: treePayload,
+    },
+    commitRequest: {
+      method: 'POST',
+      body: commitPayload,
+    },
+    refUpdateRequest: {
+      method: 'PATCH',
+      body: {
+        sha: '<RELEASE_COMMIT_SHA_PLACEHOLDER>',
+        force: false,
+      },
+    },
+  },
+  tagPlan: options.includeTag
+    ? {
+        tagObjectEndpoint: `/repos/${normalizedRepo}/git/tags`,
+        tagRefEndpoint: `/repos/${normalizedRepo}/git/refs`,
+        tagObjectRequest: {
+          method: 'POST',
+          body: tagPayload,
+        },
+        tagRefRequest: {
+          method: 'POST',
+          body: {
+            ref: `refs/tags/${options.version}`,
+            sha: '<TAG_OBJECT_SHA_PLACEHOLDER>',
+          },
+        },
+      }
+    : null,
+  shellPlan: {
+    createBlobCommands: entries.map(
+      entry =>
+        `gh api "/repos/${normalizedRepo}/git/blobs" --method POST --field content='${entry.contentBase64}' --field encoding='base64'`
+    ),
+    createTreeCommand: `cat <<'JSON' | jq '.base_tree = "${options.baseTree}"' > /tmp/changelog-tree.json; gh api "/repos/${normalizedRepo}/git/trees" --method POST --input /tmp/changelog-tree.json`,
+    createCommitCommand: `gh api "/repos/${normalizedRepo}/git/commits" --method POST --input /tmp/commit.json`,
+    updateRefCommand: `gh api "/repos/${normalizedRepo}/git/refs/heads/${options.branch}" --method PATCH --input /tmp/ref.json`,
+  },
+};
+
+if (options.includeTag) {
+  plan.tagPlan.shellPlan = {
+    createTagObjectCommand: `gh api "/repos/${normalizedRepo}/git/tags" --method POST --input /tmp/tag-object.json`,
+    createTagRefCommand: `gh api "/repos/${normalizedRepo}/git/refs" --method POST --input /tmp/tag-ref.json`,
+  };
+}
+
+if (options.output) {
+  fs.writeFileSync(options.output, `${JSON.stringify(plan, null, 2)}\n`);
+}
+
+console.log(JSON.stringify(plan, null, 2));
+
+function parseArgs(rawArgs) {
+  const values = {};
+  for (let i = 0; i < rawArgs.length; i += 1) {
+    const arg = rawArgs[i];
+    if (!arg.startsWith('--')) {
+      continue;
+    }
+    if (arg === '--file') {
+      values.files ??= [];
+      values.files.push(rawArgs[i + 1]);
+      i += 1;
+      continue;
+    }
+    if (arg === '--include-tag') {
+      values.includeTag = true;
+      continue;
+    }
+    const key = toCamelCase(arg.slice(2));
+    const next = rawArgs[i + 1];
+    if (next === undefined || next.startsWith('--')) {
+      continue;
+    }
+    values[key] = next;
+    i += 1;
+  }
+  return values;
+}
+
+function toCamelCase(value) {
+  return value
+    .split('-')
+    .map((segment, index) =>
+      index === 0 ? segment : segment.charAt(0).toUpperCase() + segment.slice(1)
+    )
+    .join('');
+}

--- a/tools/release/plan-github-update.mjs
+++ b/tools/release/plan-github-update.mjs
@@ -50,7 +50,7 @@ const entries = options.files.map(filePath => {
   };
 });
 
-const normalizedRepo = options.repo.replace(/^github\.com\//, '');
+const normalizedRepo = options.repo.replace(/^(https?:\/\/)?(github\.com\/)?/, '');
 const treePayload = {
   base_tree: options.baseTree,
   tree: entries.map(entry => ({

--- a/tools/release/prepare-release.mjs
+++ b/tools/release/prepare-release.mjs
@@ -1,0 +1,206 @@
+#!/usr/bin/env node
+/* eslint-disable no-console */
+import fs from 'node:fs';
+
+const args = parseArgs(process.argv.slice(2));
+const optionAliases = {
+  changelog: 'changelogPath',
+  moduleJson: 'moduleJsonPath',
+  readmeHtml: 'readmeHtmlPath',
+  releaseBody: 'releaseBodyPath',
+};
+
+const options = {
+  version: '',
+  releaseTitle: '',
+  releaseDescription: '',
+  moduleId: 'simulacrum',
+  repoUrl: '',
+  changelogPath: 'CHANGELOG.md',
+  moduleJsonPath: 'module.json',
+  readmeHtmlPath: 'readme_single.html',
+  releaseBodyPath: 'release_body.md',
+  dryRun: false,
+  writeFiles: true,
+  summaryPath: '',
+};
+
+for (const [key, value] of Object.entries(args)) {
+  const optionKey = optionAliases[key] || key;
+  if (Object.hasOwn(options, optionKey)) {
+    options[optionKey] = value;
+  }
+}
+
+if (!options.version || !String(options.version).trim()) {
+  fail('version is required');
+}
+if (!options.releaseTitle || !String(options.releaseTitle).trim()) {
+  fail('release_title is required');
+}
+if (!options.releaseDescription || !String(options.releaseDescription).trim()) {
+  fail('release_description is required');
+}
+
+const releaseTitle = String(options.releaseTitle).trim();
+const releaseDescription = String(options.releaseDescription).trim();
+const version = String(options.version).trim();
+const repoUrl = normalizeRepoUrl(options.repoUrl);
+const moduleId = options.moduleId || 'simulacrum';
+
+if (!/^[0-9]+\.[0-9]+\.[0-9]+(-[0-9A-Za-z.-]+)?(\+[0-9A-Za-z.-]+)?$/.test(version)) {
+  fail('version must be SemVer without a leading v');
+}
+if (releaseTitle === version || releaseTitle === `v${version}` || !/[A-Za-z]/.test(releaseTitle)) {
+  fail('release_title must be natural prose, not just the version');
+}
+if (!/[A-Za-z]/.test(releaseDescription) || releaseDescription.split(/\s+/).length < 3) {
+  fail('release_description must be a natural-prose descriptor');
+}
+
+const changelog = readText(options.changelogPath, 'CHANGELOG.md');
+const unreleasedSection = findUnreleasedSection(changelog);
+if (!unreleasedSection) {
+  fail('CHANGELOG.md is missing a [Unreleased] section');
+}
+
+const date = new Date().toISOString().slice(0, 10);
+const releaseHeader = `## [${version}] - ${date}`;
+const releaseSection = unreleasedSection.text.replace(/^## \[Unreleased\][^\n]*$/m, releaseHeader);
+const releaseSectionContent = releaseSection.replace(/^## \[[^\]]+\][^\n]*\n?/m, '');
+
+const releaseBody = [releaseDescription, releaseSectionContent.trim()].filter(Boolean).join('\n\n');
+if (!releaseBody.trim()) {
+  fail('release body would be empty');
+}
+
+const moduleJson = safeJsonParse(readText(options.moduleJsonPath, 'module.json'));
+moduleJson.version = version;
+moduleJson.manifest = `${repoUrl}/releases/download/${version}/module.json`;
+moduleJson.download = `${repoUrl}/releases/download/${version}/${moduleId}.zip`;
+if (fs.existsSync(options.readmeHtmlPath)) {
+  moduleJson.description = readText(options.readmeHtmlPath, options.readmeHtmlPath).trim();
+}
+
+const updatedChangelog = [
+  changelog.slice(0, unreleasedSection.start),
+  releaseSection.trimEnd(),
+  '\n\n',
+  changelog.slice(unreleasedSection.end).replace(/^\n+/, ''),
+].join('');
+const changedChangelog = updatedChangelog !== changelog;
+const nextModuleJsonText = `${JSON.stringify(moduleJson, null, 2)}\n`;
+const currentModuleJsonText = readText(options.moduleJsonPath, 'module.json');
+const changedModuleJson = nextModuleJsonText !== currentModuleJsonText;
+
+if (options.writeFiles && !options.dryRun) {
+  if (changedChangelog) {
+    fs.writeFileSync(options.changelogPath, updatedChangelog);
+  }
+  if (changedModuleJson) {
+    fs.writeFileSync(options.moduleJsonPath, nextModuleJsonText);
+  }
+}
+fs.writeFileSync(options.releaseBodyPath, `${releaseBody.trim()}\n`);
+
+const summary = {
+  version,
+  releaseTitle,
+  releaseBodyPath: options.releaseBodyPath,
+  releaseSection,
+  changelogUpdated: changedChangelog,
+  moduleJsonUpdated: changedModuleJson,
+  dryRun: options.dryRun,
+  writeFiles: options.writeFiles,
+  commitSafe: !!changedChangelog || !!changedModuleJson,
+  errors: [],
+};
+
+if (options.summaryPath) {
+  fs.writeFileSync(options.summaryPath, `${JSON.stringify(summary, null, 2)}\n`);
+}
+
+console.log(JSON.stringify(summary, null, 2));
+
+function parseArgs(rawArgs) {
+  const values = {};
+  for (let i = 0; i < rawArgs.length; i += 1) {
+    const arg = rawArgs[i];
+    if (!arg.startsWith('--')) {
+      continue;
+    }
+    if (arg === '--dry-run') {
+      values.dryRun = true;
+      continue;
+    }
+    if (arg === '--write') {
+      values.writeFiles = true;
+      continue;
+    }
+    const key = toCamelCase(arg.replace(/^--/, ''));
+    const next = rawArgs[i + 1];
+    if (next === undefined || next.startsWith('--')) {
+      values[key] = 'true';
+      continue;
+    }
+    values[key] = next;
+    i += 1;
+  }
+  if (!rawArgs.includes('--write')) {
+    values.writeFiles = false;
+  }
+  return values;
+}
+
+function toCamelCase(value) {
+  return value
+    .split('-')
+    .map((segment, index) =>
+      index === 0 ? segment : segment.charAt(0).toUpperCase() + segment.slice(1)
+    )
+    .join('');
+}
+
+function normalizeRepoUrl(value) {
+  if (!value || !String(value).trim()) {
+    fail('repo URL is required');
+  }
+  return value.replace(/\/$/, '');
+}
+
+function readText(filePath, label) {
+  try {
+    return fs.readFileSync(filePath, 'utf8');
+  } catch (error) {
+    fail(`Unable to read ${label}: ${error.message}`);
+  }
+}
+
+function safeJsonParse(value) {
+  try {
+    return JSON.parse(value);
+  } catch (error) {
+    fail(`Invalid JSON input: ${error.message}`);
+  }
+}
+
+function findUnreleasedSection(content) {
+  const headingMatch = /^## \[Unreleased\][^\n]*$/m.exec(content);
+  if (!headingMatch) {
+    return null;
+  }
+  const start = headingMatch.index;
+  const nextSearchStart = start + headingMatch[0].length + 1;
+  const nextHeadingMatch = /^## \[/m.exec(content.slice(nextSearchStart));
+  const end = nextHeadingMatch ? nextSearchStart + nextHeadingMatch.index : content.length;
+  return {
+    start,
+    end,
+    text: content.slice(start, end),
+  };
+}
+
+function fail(message) {
+  console.error(message);
+  process.exit(1);
+}

--- a/tools/release/prepare-release.mjs
+++ b/tools/release/prepare-release.mjs
@@ -51,10 +51,10 @@ const moduleId = options.moduleId || 'simulacrum';
 if (!/^[0-9]+\.[0-9]+\.[0-9]+(-[0-9A-Za-z.-]+)?(\+[0-9A-Za-z.-]+)?$/.test(version)) {
   fail('version must be SemVer without a leading v');
 }
-if (releaseTitle === version || releaseTitle === `v${version}` || !/[A-Za-z]/.test(releaseTitle)) {
+if (releaseTitle === version || releaseTitle === `v${version}` || !/\p{L}/u.test(releaseTitle)) {
   fail('release_title must be natural prose, not just the version');
 }
-if (!/[A-Za-z]/.test(releaseDescription) || releaseDescription.split(/\s+/).length < 3) {
+if (!/\p{L}/u.test(releaseDescription) || releaseDescription.split(/\s+/).length < 3) {
   fail('release_description must be a natural-prose descriptor');
 }
 
@@ -100,8 +100,8 @@ if (options.writeFiles && !options.dryRun) {
   if (changedModuleJson) {
     fs.writeFileSync(options.moduleJsonPath, nextModuleJsonText);
   }
+  fs.writeFileSync(options.releaseBodyPath, `${releaseBody.trim()}\n`);
 }
-fs.writeFileSync(options.releaseBodyPath, `${releaseBody.trim()}\n`);
 
 const summary = {
   version,
@@ -146,7 +146,7 @@ function parseArgs(rawArgs) {
     values[key] = next;
     i += 1;
   }
-  if (!rawArgs.includes('--write')) {
+  if (values.writeFiles === undefined) {
     values.writeFiles = false;
   }
   return values;


### PR DESCRIPTION
## Summary

Updates release automation so versioned releases and post-merge changelog updates are handled by separate, validated workflows.

- Updates `create-release.yml` to require `version`, `release_title`, and `release_description`; dry runs default to true.
- Uses the release GitHub App token with `permission-contents: write` and Git database API payloads for atomic release commits and tags.
- Keeps dry-run dispatches on the selected branch for validation, while real releases operate on `main`.
- Adds `update-changelog.yml` as the post-merge `main` trigger for product-facing `[Unreleased]` updates.
- Adds release helper scripts for product-path changelog generation, release metadata preparation, and Git database payload planning.
- Extends the required `Lint & Format` workflow so changed workflows and `tools/**/*.mjs` helpers are checked.
- Updates workflow actions for the current Node 24 GitHub Actions runtime (`actions/checkout@v6`, `actions/setup-node@v6`, `softprops/action-gh-release@v3`).
- Regenerates `[Unreleased]` with product-facing module changes only; CI/meta-only changes are excluded.

## Validation

- `npm ci`
- `npx prettier --check .github/workflows/ci.yml .github/workflows/create-release.yml .github/workflows/update-changelog.yml CHANGELOG.md tools/release/generate-unreleased-changelog.mjs tools/release/prepare-release.mjs tools/release/plan-github-update.mjs`
- `npx eslint tools/release/*.mjs`
- `node --check` for all three `tools/release/*.mjs` helpers.
- YAML parse of workflow files with Python/PyYAML.
- Workflow `run:` blocks parsed with `bash -n` after expression placeholder substitution.
- `node tools/release/generate-unreleased-changelog.mjs --dry-run` produced 5 product-facing entries since `1.0.9` and no CI/meta entries.
- Release-prep write test produced versioned `module.json`, `CHANGELOG.md`, and non-empty release body output for `1.1.0`.
- Git database plan test produced repo-relative `module.json`/`CHANGELOG.md` paths, `force: false`, and `refs/tags/1.1.0`.
- `npm run build:packs`
- Live `Update Changelog` dry run passed: https://github.com/Daxiongmao87/simulacrum-foundry/actions/runs/27834056158
- Live `Create Release` dry run passed: https://github.com/Daxiongmao87/simulacrum-foundry/actions/runs/27834056216
- `GitGuardian Security Checks` passed on the PR head.

Known local non-blocker: full-repo `npm run lint:check` and `npm run format:check` still fail on pre-existing unrelated repo debt; the required PR workflow is changed-file scoped and covers this PR's workflows and release helpers.
