### PR TITLE
ci: fix Discord release announcement workflow

### DIFF
--- a/.github/workflows/create-release.yml
+++ b/.github/workflows/create-release.yml
@@ -19,6 +19,11 @@ on:
         description: 'Release notes description to prepend (required)'
         required: true
         type: string
+      announce_only:
+        description: 'Announce an already-created release without mutating GitHub/Foundry artifacts'
+        required: false
+        type: boolean
+        default: false
       dry_run:
         description: 'Validate release metadata and payloads without mutating GitHub'
         required: false
@@ -46,7 +51,7 @@ jobs:
         uses: actions/checkout@v6
         with:
           fetch-depth: 0
-          ref: ${{ inputs.dry_run && github.ref_name || 'main' }}
+          ref: ${{ (inputs.dry_run || inputs.announce_only) && github.ref_name || 'main' }}
           token: ${{ steps.release-token.outputs.token }}
 
       - name: Validate release inputs
@@ -54,6 +59,7 @@ jobs:
           VERSION: ${{ inputs.version }}
           RELEASE_TITLE: ${{ inputs.release_title }}
           RELEASE_DESCRIPTION: ${{ inputs.release_description }}
+          GH_TOKEN: ${{ steps.release-token.outputs.token }}
         run: |
           set -euo pipefail
 
@@ -72,21 +78,31 @@ jobs:
             exit 1
           fi
 
-          if git ls-remote --exit-code --tags origin "refs/tags/${VERSION}" >/dev/null 2>&1; then
-            echo "::error::tag refs/tags/${VERSION} already exists"
-            exit 1
+          if [ "${{ inputs.announce_only }}" != "true" ]; then
+            if git ls-remote --exit-code --tags origin "refs/tags/${VERSION}" >/dev/null 2>&1; then
+              echo "::error::tag refs/tags/${VERSION} already exists"
+              exit 1
+            fi
+          else
+            if ! gh release view "${VERSION}" --repo "${GITHUB_REPOSITORY}" >/dev/null 2>&1; then
+              echo "::error::GitHub release for ${VERSION} does not exist"
+              exit 1
+            fi
           fi
 
       - name: Setup Node.js
+        if: inputs.announce_only == false
         uses: actions/setup-node@v6
         with:
           node-version: '24'
           cache: 'npm'
 
       - name: Install dependencies
+        if: inputs.announce_only == false
         run: npm ci
 
       - name: Convert README to HTML description
+        if: inputs.announce_only == false
         env:
           REPO_RAW: https://raw.githubusercontent.com/${{ github.repository }}/main
         run: |
@@ -103,6 +119,7 @@ jobs:
 
       - name: Prepare release metadata
         id: prepare-release
+        if: inputs.announce_only == false
         env:
           VERSION: ${{ inputs.version }}
           RELEASE_TITLE: ${{ inputs.release_title }}
@@ -141,9 +158,11 @@ jobs:
           fi
 
       - name: Build compendium packs
+        if: inputs.announce_only == false
         run: npm run build:packs
 
       - name: Create module zip
+        if: inputs.announce_only == false
         run: |
           mkdir -p dist/${{ env.MODULE_ID }}
           cp -r assets dist/${{ env.MODULE_ID }}/
@@ -164,6 +183,7 @@ jobs:
           rm -f readme_single.html readme.html
 
       - name: Resolve release bot identity
+        if: inputs.announce_only == false
         id: bot-user
         env:
           GH_TOKEN: ${{ steps.release-token.outputs.token }}
@@ -171,6 +191,7 @@ jobs:
           echo "user-id=$(gh api "/users/${{ steps.release-token.outputs.app-slug }}[bot]" --jq .id)" >> "$GITHUB_OUTPUT"
 
       - name: Plan atomic commit and tag payloads
+        if: inputs.announce_only == false
         id: github-plan
         run: |
           node tools/release/plan-github-update.mjs \
@@ -187,7 +208,7 @@ jobs:
             --output /tmp/github-plan.json
 
       - name: Create release Git database commit and tag
-        if: inputs.dry_run == false
+        if: inputs.dry_run == false && inputs.announce_only == false
         env:
           GH_TOKEN: ${{ steps.release-token.outputs.token }}
         run: |
@@ -308,13 +329,13 @@ jobs:
           echo "release_commit_sha=$RELEASE_COMMIT_SHA" >> "$GITHUB_OUTPUT"
 
       - name: Show planned API payloads (dry run)
-        if: inputs.dry_run == true
+        if: inputs.dry_run == true && inputs.announce_only == false
         run: |
           echo "Planned payload for module/release commit and tag:"
           cat /tmp/github-plan.json
 
       - name: Create GitHub Release
-        if: inputs.dry_run == false
+        if: inputs.dry_run == false && inputs.announce_only == false
         uses: softprops/action-gh-release@v3
         with:
           tag_name: ${{ inputs.version }}
@@ -328,7 +349,7 @@ jobs:
           GITHUB_TOKEN: ${{ steps.release-token.outputs.token }}
 
       - name: Publish to Foundry VTT
-        if: inputs.dry_run == false
+        if: inputs.dry_run == false && inputs.announce_only == false
         env:
           FVTT_TOKEN: ${{ secrets.FOUNDRY_RELEASE_TOKEN }}
         run: |
@@ -361,7 +382,7 @@ jobs:
           CHANGELOG_FILE=changelog.txt
           awk -v version="$VERSION" '
             $0 == "## [" version "]" || index($0, "## [" version "] - ") == 1 { found=1; next }
-            found && /^## \\[/ { exit }
+            found && /^## \[/ { exit }
             found { print }
           ' CHANGELOG.md > "$CHANGELOG_FILE"
           CHANGELOG=$(cat "$CHANGELOG_FILE")


### PR DESCRIPTION
## Summary
- fixes the malformed awk regex in the Discord release announcement step
- adds announce_only dispatch mode for announcing an already-created release without mutating GitHub releases, tags, ZIP assets, or Foundry publishing

## Verification
- git diff --check
- npx prettier --check .github/workflows/create-release.yml
- Create Release announce-only run 27876078516 completed successfully; mutation steps were skipped and Announce on Discord succeeded

Release recovery run: https://github.com/Daxiongmao87/simulacrum-foundry/actions/runs/27876078516