### PR TITLE
fix(changelog): exclude CI-only entries

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,7 +11,6 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 - release: advertise Foundry VTT 14 compatibility (#168)
 
-
 ## [1.1.0] - 2026-06-20
 
 ### Fixed
@@ -34,7 +33,6 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - style: format codebase with prettier
 - fix: sanitize innerHTML usage in sidebar tab (Fixes #112)
 - fix: resolve null derefs, dead code, API key leak, and game.packs guards
-- fix(ci): fix Discord announcement exceeding embed field char limit
 
 ## [1.0.8] - 2026-02-08
 
@@ -73,7 +71,6 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ### Changed
 
 - fix: Ollama integration - race conditions, non-blocking validation, token limit consolidation
-- fix(ci): Fix shell quoting in Discord announcement step
 
 ## [1.0.6] - 2026-02-05
 
@@ -132,16 +129,13 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Changed
 
-- ci: switch to manual workflow_dispatch for releases
 - docs: add CONTRIBUTING.md with commit conventions
 - fix: correct content/display pattern in list_documents tool
 - feat: collapse tool justifications by default for completed tools (Ref #105)
 - fix: update read registry after successful document update
 - docs: suggest 200-line default chunk size for read_tool_output
 - docs: reorganize README badges with prominent Discord and FoundryVTT links
-- ci: add Discord announcement on release
 - chore: update build info
-- ci: auto-convert README to HTML for FoundryVTT package description
 - feat: show task name in task tracker header
 - feat: add step separators and skip justification for self-explanatory tools
 - docs: add badges to README

--- a/package.json
+++ b/package.json
@@ -21,7 +21,8 @@
     "test:e2e": "npx playwright test --config=tests/e2e/playwright.config.mjs",
     "test:e2e:ui": "npx playwright test --config=tests/e2e/playwright.config.mjs --ui",
     "test:e2e:headed": "npx playwright test --config=tests/e2e/playwright.config.mjs --headed",
-    "test:e2e:debug": "npx playwright test --config=tests/e2e/playwright.config.mjs --debug"
+    "test:e2e:debug": "npx playwright test --config=tests/e2e/playwright.config.mjs --debug",
+    "test:changelog": "node tests/utils/test-generate-unreleased-changelog.mjs"
   },
   "devDependencies": {
     "@foundryvtt/foundryvtt-cli": "^3.0.2",

--- a/tests/utils/test-generate-unreleased-changelog.mjs
+++ b/tests/utils/test-generate-unreleased-changelog.mjs
@@ -51,14 +51,14 @@ if (releaseCommit) {
   grouped[releaseCommit.section].push(releaseCommit.entry);
 }
 
-const generatedSection = generateSection('2026-06-20', grouped, CHANGELOG_HEADINGS);
+const resultSection = generateSection('2026-06-20', grouped, CHANGELOG_HEADINGS);
 assert.equal(
-  generatedSection.includes('### CI/CD'),
+  resultSection.includes('### CI/CD'),
   false,
   'generated section must omit CI/CD heading'
 );
 assert.equal(
-  generatedSection.includes('- release: advertise Foundry VTT 14 compatibility (#168)'),
+  resultSection.includes('- release: advertise Foundry VTT 14 compatibility (#168)'),
   true,
   'generated section must include non-CI release commit'
 );

--- a/tests/utils/test-generate-unreleased-changelog.mjs
+++ b/tests/utils/test-generate-unreleased-changelog.mjs
@@ -1,0 +1,64 @@
+import assert from 'node:assert/strict';
+import {
+  CHANGELOG_HEADINGS,
+  DEFAULT_INCLUDE_PATHS,
+  generateSection,
+  mapCommitToEntry,
+} from '../../tools/release/generate-unreleased-changelog.mjs';
+
+const includePaths = [...DEFAULT_INCLUDE_PATHS];
+
+const ciCommit = mapCommitToEntry({
+  commit: { releaseSubject: 'ci: switch to manual workflow_dispatch for releases' },
+  includePaths,
+  changedFiles: ['module.json'],
+});
+const ciScopedCommit = mapCommitToEntry({
+  commit: {
+    releaseSubject: 'fix(ci): fix Discord announcement exceeding embed field char limit',
+  },
+  includePaths,
+  changedFiles: ['module.json'],
+});
+const releaseCommit = mapCommitToEntry({
+  commit: { releaseSubject: 'fix(release): advertise Foundry VTT 14 compatibility (#168)' },
+  includePaths,
+  changedFiles: ['module.json'],
+});
+const nonProductCommit = mapCommitToEntry({
+  commit: { releaseSubject: 'fix(ci): shell script cleanup' },
+  includePaths,
+  changedFiles: ['tests/utils/test-generate-unreleased-changelog.mjs'],
+});
+
+assert.equal(ciCommit, null, 'ci commits should be skipped from product changelog');
+assert.equal(ciScopedCommit, null, 'fix(ci) commits should be skipped from product changelog');
+assert.equal(nonProductCommit, null, 'commits without product path changes should be skipped');
+assert.notEqual(releaseCommit, null, 'non-CI release commit should be included');
+assert.equal(
+  releaseCommit.section,
+  'Fixed',
+  'release-scope commit should still map to the Fixed section'
+);
+assert.equal(
+  releaseCommit.entry,
+  'release: advertise Foundry VTT 14 compatibility (#168)',
+  'release entry text should be preserved when not CI'
+);
+
+const grouped = Object.fromEntries(CHANGELOG_HEADINGS.map(heading => [heading, []]));
+if (releaseCommit) {
+  grouped[releaseCommit.section].push(releaseCommit.entry);
+}
+
+const generatedSection = generateSection('2026-06-20', grouped, CHANGELOG_HEADINGS);
+assert.equal(
+  generatedSection.includes('### CI/CD'),
+  false,
+  'generated section must omit CI/CD heading'
+);
+assert.equal(
+  generatedSection.includes('- release: advertise Foundry VTT 14 compatibility (#168)'),
+  true,
+  'generated section must include non-CI release commit'
+);

--- a/tools/release/generate-unreleased-changelog.mjs
+++ b/tools/release/generate-unreleased-changelog.mjs
@@ -2,154 +2,180 @@
 /* eslint-disable no-console */
 import { execSync } from 'node:child_process';
 import fs from 'node:fs';
+import { fileURLToPath } from 'node:url';
 
-const args = parseArgs(process.argv.slice(2));
+const conventionalCommitRegex = /^([a-z]+)(\([^)]+\))?:\s*(.*)$/i;
+const SKIP_MESSAGE_PATTERNS = [
+  /^docs\(release\):/i,
+  /^docs:\s*update unreleased changelog/i,
+  /\[skip ci\]/i,
+];
+export const CHANGELOG_HEADINGS = [
+  'Added',
+  'Changed',
+  'Fixed',
+  'Deprecated',
+  'Removed',
+  'Security',
+  'Documentation',
+  'Testing',
+  'Build',
+  'Other',
+];
+export const DEFAULT_INCLUDE_PATHS = [
+  'scripts',
+  'styles',
+  'templates',
+  'lang',
+  'assets',
+  'packs',
+  'module.json',
+  'README.md',
+];
 const optionAliases = {
   changelog: 'changelogPath',
   summary: 'summaryPath',
 };
 
-const options = {
-  changelogPath: 'CHANGELOG.md',
-  repoRoot: process.cwd(),
-  dryRun: false,
-  writeFile: false,
-  includePaths: [
-    'scripts',
-    'styles',
-    'templates',
-    'lang',
-    'assets',
-    'packs',
-    'module.json',
-    'README.md',
-  ],
-  summaryPath: '',
-};
+function buildGeneratorOptions(rawArgs = {}) {
+  const options = {
+    changelogPath: 'CHANGELOG.md',
+    repoRoot: process.cwd(),
+    dryRun: false,
+    writeFile: false,
+    includePaths: DEFAULT_INCLUDE_PATHS,
+    summaryPath: '',
+  };
 
-for (const [key, value] of Object.entries(args)) {
-  const optionKey = optionAliases[key] || key;
-  if (Object.hasOwn(options, optionKey)) {
-    options[optionKey] = value;
+  for (const [key, value] of Object.entries(rawArgs)) {
+    const optionKey = optionAliases[key] || key;
+    if (Object.hasOwn(options, optionKey)) {
+      options[optionKey] = value;
+    }
+  }
+
+  return {
+    ...options,
+    includePaths: options.includePaths.map(entry => entry.replace(/\/+$/, '')),
+  };
+}
+
+function runGenerator() {
+  const options = buildGeneratorOptions(parseArgs(process.argv.slice(2)));
+  const changelog = readText(options.changelogPath);
+  const includePaths = options.includePaths;
+  const commits = collectReleaseCommits(options);
+  const grouped = buildSectionedEntries({ commits, includePaths, repoRoot: options.repoRoot });
+  const hasUpdates = hasAnyEntries(grouped);
+  const releaseDate = new Date().toISOString().slice(0, 10);
+  const headingOrder = [...CHANGELOG_HEADINGS];
+  const newSection = hasUpdates
+    ? generateSection(releaseDate, grouped, headingOrder)
+    : `## [Unreleased] - ${releaseDate}\n`;
+  const nextChangelog = hasUpdates ? replaceUnreleasedSection(changelog, newSection) : changelog;
+  const entryCount = Object.values(grouped).reduce((count, entries) => count + entries.length, 0);
+
+  if (options.writeFile && hasUpdates) {
+    fs.writeFileSync(options.changelogPath, nextChangelog);
+  }
+
+  const summary = {
+    changelogPath: options.changelogPath,
+    generatedAt: new Date().toISOString(),
+    latestReleaseTag: resolveLatestReleaseTag(options),
+    hasUpdates,
+    dryRun: options.dryRun || !options.writeFile,
+    writeFile: options.writeFile,
+    headingOrder,
+    entryCount,
+    sectionLines: newSection.trim(),
+  };
+
+  if (options.summaryPath) {
+    fs.writeFileSync(options.summaryPath, `${JSON.stringify(summary, null, 2)}\n`);
+  }
+
+  console.log(JSON.stringify(summary, null, 2));
+
+  if (options.writeFile && !hasUpdates) {
+    console.log('{"hasUpdates": false, "message": "No product-facing commits found"}');
   }
 }
 
-const changelog = readText(options.changelogPath);
-const includePaths = options.includePaths.map(entry => entry.replace(/\/+$/, ''));
-const skipMessagePatterns = [
-  /^docs\(release\):/i,
-  /^docs:\s*update unreleased changelog/i,
-  /\[skip ci\]/i,
-];
+if (process.argv[1] === fileURLToPath(import.meta.url)) {
+  runGenerator();
+}
 
-const latestTag = resolveLatestReleaseTag();
-const range = latestTag ? `${latestTag}..HEAD` : '';
-const commits = runGitLog(`git log --first-parent --pretty=format:%H ${range}`, options.repoRoot)
-  .split('\n')
-  .map(sha => sha.trim())
-  .filter(Boolean)
-  .map(sha => {
-    const subject = runGitLog(`git show -s --format=%s ${sha}`, options.repoRoot).trim();
-    const body = runGitLog(`git show -s --format=%b ${sha}`, options.repoRoot).trim();
-    return { sha, subject, body, releaseSubject: releaseSubjectForCommit(subject, body) };
-  })
-  .filter(entry => entry.sha && entry.releaseSubject);
+function collectReleaseCommits(options) {
+  const latestTag = resolveLatestReleaseTag(options);
+  const range = latestTag ? `${latestTag}..HEAD` : '';
+  return runGitLog(`git log --first-parent --pretty=format:%H ${range}`, options.repoRoot)
+    .split('\n')
+    .map(sha => sha.trim())
+    .filter(Boolean)
+    .map(sha => {
+      const subject = runGitLog(`git show -s --format=%s ${sha}`, options.repoRoot).trim();
+      const body = runGitLog(`git show -s --format=%b ${sha}`, options.repoRoot).trim();
+      return { sha, subject, body, releaseSubject: releaseSubjectForCommit(subject, body) };
+    })
+    .filter(entry => entry.sha && entry.releaseSubject);
+}
 
-const grouped = {
-  Added: [],
-  Changed: [],
-  Fixed: [],
-  Deprecated: [],
-  Removed: [],
-  Security: [],
-  Documentation: [],
-  Testing: [],
-  'CI/CD': [],
-  Build: [],
-  Other: [],
-};
-const headingOrder = Object.keys(grouped);
-
-for (const commit of commits) {
-  if (
-    skipMessagePatterns.some(
-      pattern => pattern.test(commit.subject) || pattern.test(commit.releaseSubject)
-    )
-  ) {
-    continue;
+function buildSectionedEntries({ commits, includePaths, repoRoot }) {
+  const grouped = createSectionedEntries();
+  for (const commit of commits) {
+    if (shouldSkipCommit(commit, SKIP_MESSAGE_PATTERNS)) {
+      continue;
+    }
+    const changedFiles = changedFilesForCommit(commit.sha, repoRoot);
+    const mapped = mapCommitToEntry({ commit, includePaths, changedFiles });
+    if (mapped) {
+      addEntry(grouped, mapped.section, mapped.entry);
+    }
   }
+  return grouped;
+}
 
-  const changedFiles = changedFilesForCommit(commit.sha);
-
-  const hasRelevantChange = changedFiles.some(filePath =>
-    isRelevantProductPath(filePath, includePaths)
+function shouldSkipCommit(commit, skipPatterns) {
+  return skipPatterns.some(
+    pattern => pattern.test(commit.subject) || pattern.test(commit.releaseSubject)
   );
-  if (!hasRelevantChange) {
-    continue;
-  }
+}
 
-  const parsed = /^([a-z]+)(\([^)]+\))?:\s*(.*)$/i.exec(commit.releaseSubject);
-  const rawType = parsed ? parsed[1].toLowerCase() : 'other';
-  const scope = parsed?.[2] ? `${parsed[2].slice(1, -1)}: ` : '';
-  const message = (parsed?.[3] || commit.releaseSubject).trim() || 'chore: change';
-  const section = parsed ? sectionForType(rawType) : sectionForFreeformSubject(message);
-  const entry = `${scope}${message}`;
+function createSectionedEntries() {
+  return Object.fromEntries(CHANGELOG_HEADINGS.map(heading => [heading, []]));
+}
+
+function addEntry(grouped, section, entry) {
   if (!grouped[section].includes(entry)) {
     grouped[section].push(entry);
   }
 }
 
-const hasUpdates = Object.values(grouped).some(entries => entries.length > 0);
-const releaseDate = new Date().toISOString().slice(0, 10);
-const newSection = hasUpdates
-  ? generateSection(releaseDate, grouped, headingOrder)
-  : `## [Unreleased] - ${releaseDate}\n`;
+function hasAnyEntries(grouped) {
+  return Object.values(grouped).some(entries => entries.length > 0);
+}
 
-let nextChangelog = changelog;
-
-if (hasUpdates) {
+function replaceUnreleasedSection(changelog, newSection) {
   const existingUnreleased = findUnreleasedSection(changelog);
-  if (existingUnreleased) {
-    nextChangelog = [
-      changelog.slice(0, existingUnreleased.start),
-      newSection.trimEnd(),
-      '\n\n',
-      changelog.slice(existingUnreleased.end).replace(/^\n+/, ''),
-    ].join('');
-  } else {
-    const insertionPoint = changelog.indexOf('\n## [');
-    if (insertionPoint === -1) {
-      nextChangelog = `${changelog.trimEnd()}\n\n${newSection}\n`;
-    } else {
-      nextChangelog = `${changelog.slice(0, insertionPoint + 1)}${newSection}\n${changelog.slice(insertionPoint + 1)}`;
-    }
+  if (!existingUnreleased) {
+    return insertNewUnreleasedSection(changelog, newSection);
   }
+  return [
+    changelog.slice(0, existingUnreleased.start),
+    newSection.trimEnd(),
+    '\n\n',
+    changelog.slice(existingUnreleased.end).replace(/^\n+/, ''),
+  ].join('');
 }
 
-if (options.writeFile && hasUpdates) {
-  fs.writeFileSync(options.changelogPath, nextChangelog);
-}
-
-const summary = {
-  changelogPath: options.changelogPath,
-  generatedAt: new Date().toISOString(),
-  latestReleaseTag: latestTag,
-  hasUpdates,
-  dryRun: options.dryRun || !options.writeFile,
-  writeFile: options.writeFile,
-  headingOrder,
-  entryCount: Object.values(grouped).reduce((count, entries) => count + entries.length, 0),
-  sectionLines: newSection.trim(),
-};
-
-if (options.summaryPath) {
-  fs.writeFileSync(options.summaryPath, `${JSON.stringify(summary, null, 2)}\n`);
-}
-
-console.log(JSON.stringify(summary, null, 2));
-
-if (options.writeFile && !hasUpdates) {
-  console.log('{"hasUpdates": false, "message": "No product-facing commits found"}');
+function insertNewUnreleasedSection(changelog, newSection) {
+  const insertionPoint = changelog.indexOf('\n## [');
+  if (insertionPoint === -1) {
+    return `${changelog.trimEnd()}\n\n${newSection}\n`;
+  }
+  const insertionAnchor = insertionPoint + 1;
+  return `${changelog.slice(0, insertionAnchor)}${newSection}\n${changelog.slice(insertionAnchor)}`;
 }
 
 function runGitLog(command, cwd) {
@@ -179,7 +205,6 @@ function sectionForType(type) {
     refactor: 'Changed',
     perf: 'Changed',
     build: 'Build',
-    ci: 'CI/CD',
     test: 'Testing',
     tests: 'Testing',
     docs: 'Documentation',
@@ -189,6 +214,45 @@ function sectionForType(type) {
     security: 'Security',
   };
   return map[type] || 'Other';
+}
+
+export function parseConventionalCommit(subject) {
+  const parsed = conventionalCommitRegex.exec(subject || '');
+  if (!parsed) {
+    return null;
+  }
+  return {
+    type: parsed[1].toLowerCase(),
+    scope: parsed[2] ? parsed[2].slice(1, -1).trim() : '',
+    message: (parsed[3] || '').trim(),
+  };
+}
+
+export function isCiCommit(parsedCommit) {
+  if (!parsedCommit) {
+    return false;
+  }
+  return parsedCommit.type === 'ci' || parsedCommit.scope.toLowerCase() === 'ci';
+}
+
+export function mapCommitToEntry({ commit, includePaths, changedFiles }) {
+  const parsed = parseConventionalCommit(commit.releaseSubject);
+  if (isCiCommit(parsed)) {
+    return null;
+  }
+
+  const hasRelevantChange = changedFiles.some(filePath =>
+    isRelevantProductPath(filePath, includePaths)
+  );
+  if (!hasRelevantChange) {
+    return null;
+  }
+
+  const rawType = parsed ? parsed.type : 'other';
+  const scope = parsed?.scope ? `${parsed.scope}: ` : '';
+  const message = (parsed?.message || commit.releaseSubject).trim() || 'chore: change';
+  const section = parsed ? sectionForType(rawType) : sectionForFreeformSubject(message);
+  return { section, entry: `${scope}${message}` };
 }
 
 function sectionForFreeformSubject(subject) {
@@ -220,14 +284,14 @@ function releaseSubjectForCommit(subject, body) {
   return subject;
 }
 
-function changedFilesForCommit(sha) {
-  const parentLine = runGitLog(`git rev-list --parents -n 1 ${sha}`, options.repoRoot).trim();
+function changedFilesForCommit(sha, repoRoot = process.cwd()) {
+  const parentLine = runGitLog(`git rev-list --parents -n 1 ${sha}`, repoRoot).trim();
   const parentCount = parentLine ? parentLine.split(/\s+/).length - 1 : 0;
   const command =
     parentCount > 1
       ? `git diff --name-only ${sha}~1 ${sha}`
       : `git show --name-only --pretty=format: --no-renames ${sha}`;
-  return runGitLog(command, options.repoRoot)
+  return runGitLog(command, repoRoot)
     .split('\n')
     .map(filePath => filePath.trim())
     .filter(Boolean);
@@ -251,6 +315,22 @@ function isRelevantProductPath(filePath, includePaths) {
   });
 }
 
+export function generateSection(releaseDate, groupedEntries, headingOrder) {
+  const lines = [`## [Unreleased] - ${releaseDate}`, ''];
+  for (const heading of headingOrder) {
+    const entries = groupedEntries[heading];
+    if (!entries.length) {
+      continue;
+    }
+    lines.push(`### ${heading}`, '');
+    for (const entry of entries) {
+      lines.push(`- ${entry}`);
+    }
+    lines.push('');
+  }
+  return `${lines.join('\n')}\n`;
+}
+
 function findUnreleasedSection(content) {
   const headingMatch = /^## \[Unreleased\][^\n]*$/m.exec(content);
   if (!headingMatch) {
@@ -267,23 +347,7 @@ function findUnreleasedSection(content) {
   };
 }
 
-function generateSection(releaseDate, grouped, headingOrder) {
-  const lines = [`## [Unreleased] - ${releaseDate}`, ''];
-  for (const heading of headingOrder) {
-    const entries = grouped[heading];
-    if (!entries.length) {
-      continue;
-    }
-    lines.push(`### ${heading}`, '');
-    for (const entry of entries) {
-      lines.push(`- ${entry}`);
-    }
-    lines.push('');
-  }
-  return `${lines.join('\n')}\n`;
-}
-
-function resolveLatestReleaseTag() {
+function resolveLatestReleaseTag(options = { repoRoot: process.cwd() }) {
   return (
     runGitLog('git tag --sort=-version:refname', options.repoRoot)
       .split('\n')

--- a/tools/release/generate-unreleased-changelog.mjs
+++ b/tools/release/generate-unreleased-changelog.mjs
@@ -4,7 +4,7 @@ import { execSync } from 'node:child_process';
 import fs from 'node:fs';
 import { fileURLToPath } from 'node:url';
 
-const conventionalCommitRegex = /^([a-z]+)(\([^)]+\))?:\s*(.*)$/i;
+const CONVENTIONAL_COMMIT_REGEX = /^([a-z]+)(\([^)]+\))?:\s*(.*)$/i;
 const SKIP_MESSAGE_PATTERNS = [
   /^docs\(release\):/i,
   /^docs:\s*update unreleased changelog/i,
@@ -32,7 +32,7 @@ export const DEFAULT_INCLUDE_PATHS = [
   'module.json',
   'README.md',
 ];
-const optionAliases = {
+const OPTION_ALIASES = {
   changelog: 'changelogPath',
   summary: 'summaryPath',
 };
@@ -48,15 +48,20 @@ function buildGeneratorOptions(rawArgs = {}) {
   };
 
   for (const [key, value] of Object.entries(rawArgs)) {
-    const optionKey = optionAliases[key] || key;
+    const optionKey = OPTION_ALIASES[key] || key;
     if (Object.hasOwn(options, optionKey)) {
       options[optionKey] = value;
     }
   }
 
+  const includePaths =
+    typeof options.includePaths === 'string'
+      ? options.includePaths.split(',').map(path => path.trim())
+      : options.includePaths;
+
   return {
     ...options,
-    includePaths: options.includePaths.map(entry => entry.replace(/\/+$/, '')),
+    includePaths: includePaths.map(entry => entry.replace(/\/+$/, '')),
   };
 }
 
@@ -217,7 +222,7 @@ function sectionForType(type) {
 }
 
 export function parseConventionalCommit(subject) {
-  const parsed = conventionalCommitRegex.exec(subject || '');
+  const parsed = CONVENTIONAL_COMMIT_REGEX.exec(subject || '');
   if (!parsed) {
     return null;
   }
@@ -232,7 +237,7 @@ export function isCiCommit(parsedCommit) {
   if (!parsedCommit) {
     return false;
   }
-  return parsedCommit.type === 'ci' || parsedCommit.scope.toLowerCase() === 'ci';
+  return parsedCommit.type === 'ci' || parsedCommit.scope?.toLowerCase() === 'ci';
 }
 
 export function mapCommitToEntry({ commit, includePaths, changedFiles }) {


### PR DESCRIPTION
## Summary
- exclude conventional `ci:` and `*(ci):` commits from generated product changelog entries
- remove the generated `CI/CD` changelog section category
- scrub existing CI-only entries from `CHANGELOG.md`
- add a focused changelog generator regression test

## Verification
- `npm run test:changelog`
- `npx eslint tools/release/generate-unreleased-changelog.mjs tests/utils/test-generate-unreleased-changelog.mjs`
- `npx prettier --check CHANGELOG.md package.json tools/release/generate-unreleased-changelog.mjs tests/utils/test-generate-unreleased-changelog.mjs`
- `node tools/release/generate-unreleased-changelog.mjs --changelog-path CHANGELOG.md --dry-run --summary /tmp/changelog-dry-run-summary-after-format.json`
- downloaded live 1.1.0 GitHub release assets and verified both standalone and zip-embedded `module.json` still contain `minimum=13 verified=13.331 maximum=14`

## Notes
Full repo lint/format still reports pre-existing failures outside this changelog change.