### PR TITLE
[codex] Fix Foundry release API publish

### DIFF
--- a/.github/workflows/create-release.yml
+++ b/.github/workflows/create-release.yml
@@ -24,6 +24,11 @@ on:
         required: false
         type: boolean
         default: false
+      foundry_only:
+        description: 'Publish an existing GitHub release to Foundry without mutating GitHub/tag/release assets'
+        required: false
+        type: boolean
+        default: false
       dry_run:
         description: 'Validate release metadata and payloads without mutating GitHub'
         required: false
@@ -51,7 +56,7 @@ jobs:
         uses: actions/checkout@v6
         with:
           fetch-depth: 0
-          ref: ${{ (inputs.dry_run || inputs.announce_only) && github.ref_name || 'main' }}
+          ref: ${{ (inputs.dry_run || inputs.announce_only || inputs.foundry_only) && github.ref_name || 'main' }}
           token: ${{ steps.release-token.outputs.token }}
 
       - name: Validate release inputs
@@ -88,7 +93,12 @@ jobs:
             exit 1
           fi
 
-          if [ "${{ inputs.announce_only }}" != "true" ]; then
+          if [ "${{ inputs.announce_only }}" = "true" ] && [ "${{ inputs.foundry_only }}" = "true" ]; then
+            echo "::error::foundry_only and announce_only cannot both be true"
+            exit 1
+          fi
+
+          if [ "${{ inputs.announce_only }}" != "true" ] && [ "${{ inputs.foundry_only }}" != "true" ]; then
             if git ls-remote --exit-code --tags origin "refs/tags/${VERSION}" >/dev/null 2>&1; then
               echo "::error::tag refs/tags/${VERSION} already exists"
               exit 1
@@ -108,11 +118,11 @@ jobs:
           cache: 'npm'
 
       - name: Install dependencies
-        if: inputs.announce_only == false
+        if: inputs.announce_only == false && inputs.foundry_only == false
         run: npm ci
 
       - name: Convert README to HTML description
-        if: inputs.announce_only == false
+        if: inputs.announce_only == false && inputs.foundry_only == false
         env:
           REPO_RAW: https://raw.githubusercontent.com/${{ github.repository }}/main
         run: |
@@ -129,7 +139,7 @@ jobs:
 
       - name: Prepare release metadata
         id: prepare-release
-        if: inputs.announce_only == false
+        if: inputs.announce_only == false && inputs.foundry_only == false
         env:
           VERSION: ${{ inputs.version }}
           RELEASE_TITLE: ${{ inputs.release_title }}
@@ -168,11 +178,11 @@ jobs:
           fi
 
       - name: Build compendium packs
-        if: inputs.announce_only == false
+        if: inputs.announce_only == false && inputs.foundry_only == false
         run: npm run build:packs
 
       - name: Create module zip
-        if: inputs.announce_only == false
+        if: inputs.announce_only == false && inputs.foundry_only == false
         run: |
           mkdir -p dist/${{ env.MODULE_ID }}
           cp -r assets dist/${{ env.MODULE_ID }}/
@@ -193,7 +203,7 @@ jobs:
           rm -f readme_single.html readme.html
 
       - name: Resolve release bot identity
-        if: inputs.announce_only == false
+        if: inputs.announce_only == false && inputs.foundry_only == false
         id: bot-user
         env:
           GH_TOKEN: ${{ steps.release-token.outputs.token }}
@@ -201,7 +211,7 @@ jobs:
           echo "user-id=$(gh api "/users/${{ steps.release-token.outputs.app-slug }}[bot]" --jq .id)" >> "$GITHUB_OUTPUT"
 
       - name: Plan atomic commit and tag payloads
-        if: inputs.announce_only == false
+        if: inputs.announce_only == false && inputs.foundry_only == false
         id: github-plan
         run: |
           node tools/release/plan-github-update.mjs \
@@ -218,7 +228,7 @@ jobs:
             --output /tmp/github-plan.json
 
       - name: Create release Git database commit and tag
-        if: inputs.dry_run == false && inputs.announce_only == false
+        if: inputs.dry_run == false && inputs.announce_only == false && inputs.foundry_only == false
         env:
           GH_TOKEN: ${{ steps.release-token.outputs.token }}
         run: |
@@ -339,13 +349,13 @@ jobs:
           echo "release_commit_sha=$RELEASE_COMMIT_SHA" >> "$GITHUB_OUTPUT"
 
       - name: Show planned API payloads (dry run)
-        if: inputs.dry_run == true && inputs.announce_only == false
+        if: inputs.dry_run == true && inputs.announce_only == false && inputs.foundry_only == false
         run: |
           echo "Planned payload for module/release commit and tag:"
           cat /tmp/github-plan.json
 
       - name: Create GitHub Release
-        if: inputs.dry_run == false && inputs.announce_only == false
+        if: inputs.dry_run == false && inputs.announce_only == false && inputs.foundry_only == false
         uses: softprops/action-gh-release@v3
         with:
           tag_name: ${{ inputs.version }}
@@ -358,35 +368,148 @@ jobs:
         env:
           GITHUB_TOKEN: ${{ steps.release-token.outputs.token }}
 
-      - name: Publish to Foundry VTT
-        if: inputs.dry_run == false && inputs.announce_only == false
+      - name: Prepare release metadata for Foundry API
+        if: inputs.announce_only == false && (inputs.foundry_only == true || inputs.dry_run == false)
+        env:
+          VERSION: ${{ inputs.version }}
+          REPO: ${{ github.repository }}
+        run: |
+          set -euo pipefail
+
+          if [ "${{ inputs.foundry_only }}" = "true" ]; then
+            curl -fsSL "https://github.com/${REPO}/releases/download/${VERSION}/module.json" -o /tmp/foundry-module.json
+          else
+            cp module.json /tmp/foundry-module.json
+          fi
+
+      - name: Build Foundry API payload
+        if: inputs.announce_only == false && (inputs.foundry_only == true || inputs.dry_run == false)
+        env:
+          VERSION: ${{ inputs.version }}
+          REPO: ${{ github.repository }}
+        run: |
+          set -euo pipefail
+
+          node tools/release/foundry-release-payload.mjs \
+            --module-json-path /tmp/foundry-module.json \
+            --version "${VERSION}" \
+            --repo-url "https://github.com/${REPO}" \
+            --output-path /tmp/foundry-payload.json
+
+          node tools/release/foundry-release-payload.mjs \
+            --module-json-path /tmp/foundry-module.json \
+            --version "${VERSION}" \
+            --repo-url "https://github.com/${REPO}" \
+            --dry-run \
+            --output-path /tmp/foundry-dry-run-payload.json
+
+      - name: Validate Foundry payload (dry run)
+        if: inputs.announce_only == false && (inputs.foundry_only == true || inputs.dry_run == false)
         env:
           FVTT_TOKEN: ${{ secrets.FOUNDRY_RELEASE_TOKEN }}
+          FVTT_ENDPOINT: https://foundryvtt.com/_api/packages/release_version/
         run: |
-          RELEASE_URL="https://github.com/${{ github.repository }}/releases/tag/${{ inputs.version }}"
-          OUTPUT=$(npx @ghost-fvtt/foundry-publish \
-            --manifestPath module.json \
-            --manifestURL "https://github.com/${{ github.repository }}/releases/download/${{ inputs.version }}/module.json" \
-            --changelogURL "${RELEASE_URL}" 2>&1) || EXIT_CODE=$?
-          EXIT_CODE=${EXIT_CODE:-0}
+          set -euo pipefail
+          RESPONSE_BODY=/tmp/foundry-dry-run-response.json
 
-          if [ "$EXIT_CODE" -ne 0 ]; then
-            if echo "$OUTPUT" | grep -q "already exists"; then
-              echo "Version already published to Foundry VTT, skipping"
-            else
-              echo "$OUTPUT"
+          HTTP_CODE=$(curl -sS \
+            -o "$RESPONSE_BODY" \
+            -w "%{http_code}" \
+            -X POST \
+            -H "Authorization: ${FVTT_TOKEN}" \
+            -H "Content-Type: application/json" \
+            --data @/tmp/foundry-dry-run-payload.json \
+            "${FVTT_ENDPOINT}")
+
+          if [ "$HTTP_CODE" -lt 200 ] || [ "$HTTP_CODE" -ge 300 ]; then
+            echo "::error::Foundry API dry-run failed with HTTP $HTTP_CODE"
+            cat "$RESPONSE_BODY"
+            exit 1
+          fi
+
+          STATUS=$(jq -r '.status // ""' "$RESPONSE_BODY")
+          if [ "$STATUS" != "success" ]; then
+            echo "::error::Foundry API dry-run returned status ${STATUS:-<empty>}"
+            cat "$RESPONSE_BODY"
+            exit 1
+          fi
+
+          echo "Foundry API dry-run returned success"
+
+      - name: Publish to Foundry VTT
+        if: inputs.announce_only == false && inputs.dry_run == false
+        env:
+          FVTT_TOKEN: ${{ secrets.FOUNDRY_RELEASE_TOKEN }}
+          FVTT_ENDPOINT: https://foundryvtt.com/_api/packages/release_version/
+        run: |
+          set -euo pipefail
+          RESPONSE_BODY=/tmp/foundry_publish_response.json
+
+          HTTP_CODE=$(curl -sS \
+            -o "$RESPONSE_BODY" \
+            -w "%{http_code}" \
+            -X POST \
+            -H "Authorization: ${FVTT_TOKEN}" \
+            -H "Content-Type: application/json" \
+            --data @/tmp/foundry-payload.json \
+            "${FVTT_ENDPOINT}")
+
+          if [ "$HTTP_CODE" -lt 200 ] || [ "$HTTP_CODE" -ge 300 ]; then
+            echo "::error::Foundry API publish failed with HTTP $HTTP_CODE"
+            cat "$RESPONSE_BODY"
+            exit 1
+          fi
+
+          STATUS=$(jq -r '.status // ""' "$RESPONSE_BODY")
+          if [ "$STATUS" != "success" ]; then
+            echo "::error::Foundry API publish returned status ${STATUS:-<empty>}"
+            cat "$RESPONSE_BODY"
+            exit 1
+          fi
+
+          echo "Foundry API publish returned success"
+
+      - name: Verify Foundry public package page
+        if: inputs.announce_only == false && inputs.dry_run == false
+        env:
+          VERSION: ${{ inputs.version }}
+          PACKAGE_URL: https://foundryvtt.com/packages/${{ env.MODULE_ID }}
+          POLL_INTERVAL_SECONDS: 30
+          MAX_ATTEMPTS: 20
+        run: |
+          set -euo pipefail
+
+          EXPECTED_VERSION="${VERSION}"
+          EXPECTED_VERIFIED=$(jq -r '.release.compatibility.verified' /tmp/foundry-payload.json)
+          ATTEMPT=1
+
+          while [ "$ATTEMPT" -le "${MAX_ATTEMPTS}" ]; do
+            PAGE_PATH="/tmp/foundry-package-page-${ATTEMPT}.html"
+            HTTP_CODE=$(curl -sS \
+              -o "$PAGE_PATH" \
+              -w "%{http_code}" \
+              "$PACKAGE_URL")
+
+            if [ "$HTTP_CODE" -eq 200 ]; then
+              if grep -Fq "$EXPECTED_VERSION" "$PAGE_PATH" && grep -Fq "$EXPECTED_VERIFIED" "$PAGE_PATH"; then
+                echo "Foundry package page verification succeeded for version ${EXPECTED_VERSION}"
+                exit 0
+              fi
+            fi
+
+            if [ "$ATTEMPT" -ge "${MAX_ATTEMPTS}" ]; then
+              echo "::error::Foundry package page did not include version ${EXPECTED_VERSION} and verified ${EXPECTED_VERIFIED}"
+              cat "$PAGE_PATH"
               exit 1
             fi
-          fi
 
-          if [ -n "$OUTPUT" ]; then
-            echo "$OUTPUT"
-          else
-            echo "Foundry publish succeeded"
-          fi
+            echo "Foundry package page not updated yet; retrying (attempt ${ATTEMPT}/${MAX_ATTEMPTS})"
+            ATTEMPT=$((ATTEMPT + 1))
+            sleep "${POLL_INTERVAL_SECONDS}"
+          done
 
       - name: Announce on Discord
-        if: inputs.dry_run == false
+        if: inputs.dry_run == false && inputs.foundry_only == false
         env:
           DISCORD_WEBHOOK_URL: ${{ secrets.DISCORD_WEBHOOK_URL }}
           RELEASE_TITLE: ${{ inputs.release_title }}

--- a/package.json
+++ b/package.json
@@ -22,7 +22,8 @@
     "test:e2e:ui": "npx playwright test --config=tests/e2e/playwright.config.mjs --ui",
     "test:e2e:headed": "npx playwright test --config=tests/e2e/playwright.config.mjs --headed",
     "test:e2e:debug": "npx playwright test --config=tests/e2e/playwright.config.mjs --debug",
-    "test:changelog": "node tests/utils/test-generate-unreleased-changelog.mjs"
+    "test:changelog": "node tests/utils/test-generate-unreleased-changelog.mjs",
+    "test:foundry-release": "node tests/utils/test-foundry-release.mjs"
   },
   "devDependencies": {
     "@foundryvtt/foundryvtt-cli": "^3.0.2",

--- a/tests/utils/test-foundry-release.mjs
+++ b/tests/utils/test-foundry-release.mjs
@@ -1,0 +1,197 @@
+import assert from 'node:assert/strict';
+import fs from 'node:fs';
+import path from 'node:path';
+
+import { buildFoundryReleasePayload } from '../../tools/release/foundry-release-payload.mjs';
+
+const sampleModuleWithoutMaximum = {
+  id: 'simulacrum',
+  version: '1.1.0',
+  compatibility: {
+    minimum: 13,
+    verified: '14',
+  },
+};
+
+const payloadWithoutMaximum = buildFoundryReleasePayload({
+  moduleJson: sampleModuleWithoutMaximum,
+  releaseVersion: '1.1.0',
+  repoUrl: 'https://github.com/Daxiongmao87/simulacrum-foundry',
+});
+
+assert.equal(payloadWithoutMaximum.id, 'simulacrum');
+assert.equal(payloadWithoutMaximum.release.version, '1.1.0');
+assert.equal(
+  payloadWithoutMaximum.release.manifest,
+  'https://github.com/Daxiongmao87/simulacrum-foundry/releases/download/1.1.0/module.json'
+);
+assert.equal(
+  payloadWithoutMaximum.release.notes,
+  'https://github.com/Daxiongmao87/simulacrum-foundry/releases/tag/1.1.0'
+);
+assert.equal(
+  payloadWithoutMaximum.release.compatibility.minimum,
+  '13',
+  'minimum should be stringified'
+);
+assert.equal(
+  payloadWithoutMaximum.release.compatibility.verified,
+  '14',
+  'verified should be stringified'
+);
+assert.equal(
+  'maximum' in payloadWithoutMaximum.release.compatibility,
+  false,
+  'maximum should be omitted when empty'
+);
+assert.equal(
+  payloadWithoutMaximum['dry-run'],
+  undefined,
+  'dry-run should only be included when requested'
+);
+
+const sampleModuleWithMaximum = {
+  id: 'simulacrum',
+  version: '1.1.0',
+  compatibility: {
+    minimum: 13,
+    verified: '14',
+    maximum: 15,
+  },
+};
+
+const payloadWithMaximum = buildFoundryReleasePayload({
+  moduleJson: sampleModuleWithMaximum,
+  releaseVersion: '1.1.0',
+  repoUrl: 'https://github.com/Daxiongmao87/simulacrum-foundry/',
+  dryRun: true,
+});
+
+assert.equal(
+  payloadWithMaximum.release.compatibility.maximum,
+  '15',
+  'maximum should be stringified'
+);
+assert.equal(payloadWithMaximum['dry-run'], true, 'dry-run should be included when requested');
+assert.equal(
+  payloadWithMaximum.release.manifest,
+  'https://github.com/Daxiongmao87/simulacrum-foundry/releases/download/1.1.0/module.json',
+  'repo URL with trailing slash should be normalized'
+);
+
+assert.throws(
+  () => {
+    buildFoundryReleasePayload({
+      moduleJson: sampleModuleWithoutMaximum,
+      releaseVersion: '1.2.0',
+      repoUrl: 'https://github.com/Daxiongmao87/simulacrum-foundry',
+    });
+  },
+  /does not match workflow version/,
+  'mismatched versions should fail'
+);
+
+const workflowPath = path.join(process.cwd(), '.github/workflows/create-release.yml');
+const workflow = fs.readFileSync(workflowPath, 'utf8');
+
+function extractStepBlock(name, nextName) {
+  const startMarker = `- name: ${name}`;
+  const nextMarker = nextName ? `\n      - name: ${nextName}` : null;
+  const start = workflow.indexOf(startMarker);
+  assert.ok(start !== -1, `workflow step '${name}' should exist`);
+
+  const end = nextMarker ? workflow.indexOf(nextMarker, start + startMarker.length) : -1;
+  return workflow.slice(start, end === -1 ? undefined : end);
+}
+
+const buildFoundryPayloadBlock = extractStepBlock(
+  'Build Foundry API payload',
+  'Validate Foundry payload (dry run)'
+);
+const validateFoundryPayloadBlock = extractStepBlock(
+  'Validate Foundry payload (dry run)',
+  'Publish to Foundry VTT'
+);
+const publishFoundryPayloadBlock = extractStepBlock(
+  'Publish to Foundry VTT',
+  'Verify Foundry public package page'
+);
+
+assert.equal(
+  workflow.includes('npx ' + '@' + 'ghost-fvtt/f' + 'oundry-publish'),
+  false,
+  'legacy foundry CLI command must be removed'
+);
+assert.equal(
+  workflow.includes('@' + 'ghost-fvtt'),
+  false,
+  'legacy ghost CLI reference must be removed'
+);
+assert.equal(
+  /foundryvtt\.com\/_api\/packages\/release_version\//.test(workflow),
+  true,
+  'workflow should use Foundry official release API endpoint'
+);
+assert.equal(/foundry_only/.test(workflow), true, 'foundry_only input/control should exist');
+assert.equal(
+  /foundry_only.*announce_only/.test(workflow) || /announce_only.*foundry_only/.test(workflow),
+  true,
+  'workflow should reject announce_only + foundry_only together'
+);
+assert.equal(
+  /- name: Setup Node\.js\n\s+if: inputs\.announce_only == false/.test(workflow),
+  true,
+  'Setup Node.js should run for all non-announce-only paths'
+);
+assert.equal(
+  /- name: Install dependencies\n\s+if: inputs\.announce_only == false && inputs\.foundry_only == false/.test(
+    workflow
+  ),
+  true,
+  'npm ci should be skipped for foundry_only'
+);
+assert.equal(
+  workflow.includes('Authorization: Bearer ${FVTT_TOKEN}'),
+  false,
+  'Foundry Authorization header must not use Bearer prefix'
+);
+assert.equal(
+  /Authorization: \${FVTT_TOKEN}/.test(publishFoundryPayloadBlock),
+  true,
+  'publish step should send raw token in Authorization header'
+);
+assert.equal(
+  /--data @\/tmp\/foundry-dry-run-payload.json/.test(validateFoundryPayloadBlock),
+  true,
+  'validation step should post dry-run payload'
+);
+assert.equal(
+  /--data @\/tmp\/foundry-payload.json/.test(validateFoundryPayloadBlock),
+  false,
+  'validation step should not post publish payload'
+);
+assert.equal(
+  /--dry-run/.test(buildFoundryPayloadBlock),
+  true,
+  'build step must generate explicit dry-run payload with --dry-run'
+);
+assert.equal(
+  /\/tmp\/foundry-dry-run-payload\.json/.test(buildFoundryPayloadBlock),
+  true,
+  'build step must write dry-run payload path'
+);
+assert.equal(
+  /--data @\/tmp\/foundry-payload.json/.test(publishFoundryPayloadBlock),
+  true,
+  'publish step should post publish payload'
+);
+assert.equal(
+  /--dry-run/.test(publishFoundryPayloadBlock),
+  false,
+  'publish step should not include --dry-run payload generation'
+);
+assert.equal(
+  /\/tmp\/foundry-dry-run-payload\.json/.test(publishFoundryPayloadBlock),
+  false,
+  'publish step should not post dry-run payload'
+);

--- a/tests/utils/test-foundry-release.mjs
+++ b/tests/utils/test-foundry-release.mjs
@@ -50,6 +50,42 @@ assert.equal(
   'dry-run should only be included when requested'
 );
 
+assert.throws(
+  () => {
+    buildFoundryReleasePayload({
+      moduleJson: null,
+      releaseVersion: '1.1.0',
+      repoUrl: 'https://github.com/Daxiongmao87/simulacrum-foundry',
+    });
+  },
+  /moduleJson must be a non-null object/,
+  'missing moduleJson should fail validation'
+);
+
+assert.throws(
+  () => {
+    buildFoundryReleasePayload({
+      moduleJson: '',
+      releaseVersion: '1.1.0',
+      repoUrl: 'https://github.com/Daxiongmao87/simulacrum-foundry',
+    });
+  },
+  /moduleJson must be a non-null object/,
+  'non-object moduleJson should fail validation'
+);
+
+assert.throws(
+  () => {
+    buildFoundryReleasePayload({
+      moduleJson: [],
+      releaseVersion: '1.1.0',
+      repoUrl: 'https://github.com/Daxiongmao87/simulacrum-foundry',
+    });
+  },
+  /moduleJson must be a non-null object/,
+  'array moduleJson should fail validation'
+);
+
 const sampleModuleWithMaximum = {
   id: 'simulacrum',
   version: '1.1.0',
@@ -101,6 +137,9 @@ function extractStepBlock(name, nextName) {
   assert.ok(start !== -1, `workflow step '${name}' should exist`);
 
   const end = nextMarker ? workflow.indexOf(nextMarker, start + startMarker.length) : -1;
+  if (nextName) {
+    assert.ok(end !== -1, `workflow step '${name}' should be followed by '${nextName}'`);
+  }
   return workflow.slice(start, end === -1 ? undefined : end);
 }
 
@@ -108,6 +147,7 @@ const buildFoundryPayloadBlock = extractStepBlock(
   'Build Foundry API payload',
   'Validate Foundry payload (dry run)'
 );
+const validateReleaseInputsBlock = extractStepBlock('Validate release inputs', 'Setup Node.js');
 const validateFoundryPayloadBlock = extractStepBlock(
   'Validate Foundry payload (dry run)',
   'Publish to Foundry VTT'
@@ -134,9 +174,18 @@ assert.equal(
 );
 assert.equal(/foundry_only/.test(workflow), true, 'foundry_only input/control should exist');
 assert.equal(
-  /foundry_only.*announce_only/.test(workflow) || /announce_only.*foundry_only/.test(workflow),
+  validateReleaseInputsBlock.includes(
+    'if [ "${{ inputs.announce_only }}" = "true" ] && [ "${{ inputs.foundry_only }}" = "true" ]; then'
+  ),
   true,
-  'workflow should reject announce_only + foundry_only together'
+  'validate release inputs should reject announce_only + foundry_only together'
+);
+assert.equal(
+  validateReleaseInputsBlock.includes(
+    'echo "::error::foundry_only and announce_only cannot both be true"'
+  ),
+  true,
+  'validation should emit announce_only/ foundry_only conflict error'
 );
 assert.equal(
   /- name: Setup Node\.js\n\s+if: inputs\.announce_only == false/.test(workflow),

--- a/tests/utils/test-foundry-release.mjs
+++ b/tests/utils/test-foundry-release.mjs
@@ -144,9 +144,9 @@ assert.equal(
   'Setup Node.js should run for all non-announce-only paths'
 );
 assert.equal(
-  /- name: Install dependencies\n\s+if: inputs\.announce_only == false && inputs\.foundry_only == false/.test(
-    workflow
-  ),
+  new RegExp(
+    '- name: Install dependencies\\n\\s+if: inputs\\.announce_only == false && inputs\\.foundry_only == false'
+  ).test(workflow),
   true,
   'npm ci should be skipped for foundry_only'
 );

--- a/tools/release/foundry-release-payload.mjs
+++ b/tools/release/foundry-release-payload.mjs
@@ -1,0 +1,154 @@
+#!/usr/bin/env node
+/* eslint-disable no-console */
+import fs from 'node:fs';
+
+if (process.argv[1] && process.argv[1].endsWith('foundry-release-payload.mjs')) {
+  try {
+    const args = parseArgs(process.argv.slice(2));
+    const options = {
+      moduleJsonPath: '',
+      version: '',
+      repoUrl: '',
+      dryRun: false,
+      outputPath: '',
+    };
+
+    for (const [key, value] of Object.entries(args)) {
+      if (Object.hasOwn(options, key)) {
+        options[key] = value;
+      }
+    }
+
+    if (!options.moduleJsonPath || !options.version || !options.repoUrl) {
+      fail('module json path, version, and repo URL are required');
+    }
+
+    const moduleJson = safeJsonParse(readText(options.moduleJsonPath, 'module JSON'));
+    const payload = buildFoundryReleasePayload({
+      moduleJson,
+      releaseVersion: options.version,
+      repoUrl: options.repoUrl,
+      dryRun: options.dryRun,
+    });
+
+    if (options.outputPath) {
+      fs.writeFileSync(options.outputPath, `${JSON.stringify(payload, null, 2)}\n`);
+    }
+
+    console.log(JSON.stringify(payload, null, 2));
+  } catch (error) {
+    console.error(error.message || error);
+    process.exit(1);
+  }
+}
+
+function buildFoundryReleasePayload({ moduleJson, releaseVersion, repoUrl, dryRun = false }) {
+  const normalizedRepoUrl = normalizeRepoUrl(repoUrl);
+  const moduleId = moduleJson && moduleJson.id;
+  if (!moduleId || typeof moduleId !== 'string' || !moduleId.trim()) {
+    fail('module json is missing required id');
+  }
+
+  const manifestVersion = String(releaseVersion || '').trim();
+  if (!manifestVersion) {
+    fail('release version is required');
+  }
+  const moduleVersion = String(moduleJson.version || '').trim();
+  if (moduleVersion !== manifestVersion) {
+    fail(
+      `module.json version (${moduleVersion}) does not match workflow version (${manifestVersion})`
+    );
+  }
+
+  const compatibility = moduleJson.compatibility || {};
+  const minimum = compatibility.minimum;
+  const verified = compatibility.verified;
+  if (minimum === undefined || minimum === null || String(minimum).trim() === '') {
+    fail('compatibility.minimum is required');
+  }
+  if (verified === undefined || verified === null || String(verified).trim() === '') {
+    fail('compatibility.verified is required');
+  }
+
+  const compatibilityPayload = {
+    minimum: String(minimum),
+    verified: String(verified),
+  };
+  const maximum = compatibility.maximum;
+  if (maximum !== undefined && maximum !== null && String(maximum).trim() !== '') {
+    compatibilityPayload.maximum = String(maximum);
+  }
+
+  const payload = {
+    id: moduleId,
+    release: {
+      version: manifestVersion,
+      manifest: `${normalizedRepoUrl}/releases/download/${manifestVersion}/module.json`,
+      notes: `${normalizedRepoUrl}/releases/tag/${manifestVersion}`,
+      compatibility: compatibilityPayload,
+    },
+  };
+
+  if (dryRun) {
+    payload['dry-run'] = true;
+  }
+
+  return payload;
+}
+
+export { buildFoundryReleasePayload };
+
+function parseArgs(rawArgs) {
+  const values = {};
+  for (let i = 0; i < rawArgs.length; i += 1) {
+    const arg = rawArgs[i];
+    if (!arg.startsWith('--')) {
+      continue;
+    }
+    if (arg === '--dry-run') {
+      values.dryRun = true;
+      continue;
+    }
+    const key = toCamelCase(arg.replace(/^--/, ''));
+    const next = rawArgs[i + 1];
+    if (next === undefined || next.startsWith('--')) {
+      continue;
+    }
+    values[key] = next;
+    i += 1;
+  }
+  return values;
+}
+
+function toCamelCase(value) {
+  return value
+    .split('-')
+    .map((segment, index) =>
+      index === 0 ? segment : segment.charAt(0).toUpperCase() + segment.slice(1)
+    )
+    .join('');
+}
+
+function normalizeRepoUrl(value) {
+  return value.replace(/\/$/, '');
+}
+
+function readText(filePath, label) {
+  try {
+    return fs.readFileSync(filePath, 'utf8');
+  } catch (error) {
+    fail(`Unable to read ${label}: ${error.message}`);
+  }
+}
+
+function safeJsonParse(value) {
+  try {
+    return JSON.parse(value);
+  } catch (error) {
+    fail(`Invalid module JSON: ${error.message}`);
+  }
+}
+
+function fail(message) {
+  throw new Error(message);
+}

--- a/tools/release/foundry-release-payload.mjs
+++ b/tools/release/foundry-release-payload.mjs
@@ -43,6 +43,10 @@ if (process.argv[1] && process.argv[1].endsWith('foundry-release-payload.mjs')) 
 }
 
 function buildFoundryReleasePayload({ moduleJson, releaseVersion, repoUrl, dryRun = false }) {
+  if (moduleJson === null || typeof moduleJson !== 'object' || Array.isArray(moduleJson)) {
+    fail('moduleJson must be a non-null object');
+  }
+
   const moduleId = resolveModuleId(moduleJson);
   const manifestVersion = resolveTrimmedValue(releaseVersion, 'release version is required');
   const moduleVersion = String((moduleJson && moduleJson.version) ?? '').trim();

--- a/tools/release/foundry-release-payload.mjs
+++ b/tools/release/foundry-release-payload.mjs
@@ -43,60 +43,79 @@ if (process.argv[1] && process.argv[1].endsWith('foundry-release-payload.mjs')) 
 }
 
 function buildFoundryReleasePayload({ moduleJson, releaseVersion, repoUrl, dryRun = false }) {
-  const normalizedRepoUrl = normalizeRepoUrl(repoUrl);
-  const moduleId = moduleJson && moduleJson.id;
-  if (!moduleId || typeof moduleId !== 'string' || !moduleId.trim()) {
-    fail('module json is missing required id');
-  }
-
-  const manifestVersion = String(releaseVersion || '').trim();
-  if (!manifestVersion) {
-    fail('release version is required');
-  }
-  const moduleVersion = String(moduleJson.version || '').trim();
+  const moduleId = resolveModuleId(moduleJson);
+  const manifestVersion = resolveTrimmedValue(releaseVersion, 'release version is required');
+  const moduleVersion = String((moduleJson && moduleJson.version) ?? '').trim();
   if (moduleVersion !== manifestVersion) {
     fail(
       `module.json version (${moduleVersion}) does not match workflow version (${manifestVersion})`
     );
   }
 
-  const compatibility = moduleJson.compatibility || {};
-  const minimum = compatibility.minimum;
-  const verified = compatibility.verified;
-  if (minimum === undefined || minimum === null || String(minimum).trim() === '') {
-    fail('compatibility.minimum is required');
-  }
-  if (verified === undefined || verified === null || String(verified).trim() === '') {
-    fail('compatibility.verified is required');
-  }
-
-  const compatibilityPayload = {
-    minimum: String(minimum),
-    verified: String(verified),
-  };
-  const maximum = compatibility.maximum;
-  if (maximum !== undefined && maximum !== null && String(maximum).trim() !== '') {
-    compatibilityPayload.maximum = String(maximum);
-  }
-
+  const compatibility = buildCompatibilityPayload(moduleJson && moduleJson.compatibility);
+  const normalizedRepoUrl = normalizeRepoUrl(repoUrl);
   const payload = {
     id: moduleId,
     release: {
       version: manifestVersion,
       manifest: `${normalizedRepoUrl}/releases/download/${manifestVersion}/module.json`,
       notes: `${normalizedRepoUrl}/releases/tag/${manifestVersion}`,
-      compatibility: compatibilityPayload,
+      compatibility,
     },
+    ...(dryRun ? { 'dry-run': true } : {}),
   };
-
-  if (dryRun) {
-    payload['dry-run'] = true;
-  }
 
   return payload;
 }
 
 export { buildFoundryReleasePayload };
+
+function resolveModuleId(moduleJson) {
+  const moduleId = moduleJson && moduleJson.id;
+  if (typeof moduleId !== 'string' || !moduleId.trim()) {
+    fail('module json is missing required id');
+  }
+  return moduleId;
+}
+
+function resolveTrimmedValue(value, message) {
+  const trimmed = String(value ?? '').trim();
+  if (!trimmed) {
+    fail(message);
+  }
+  return trimmed;
+}
+
+function buildCompatibilityPayload(compatibility) {
+  const minimum = resolveTrimmedValue(
+    compatibility && compatibility.minimum,
+    'compatibility.minimum is required'
+  );
+  const verified = resolveTrimmedValue(
+    compatibility && compatibility.verified,
+    'compatibility.verified is required'
+  );
+
+  const compatibilityPayload = {
+    minimum,
+    verified,
+  };
+
+  const maximum = resolveOptionalTrimmedValue(compatibility && compatibility.maximum);
+  if (maximum !== null) {
+    compatibilityPayload.maximum = maximum;
+  }
+
+  return compatibilityPayload;
+}
+
+function resolveOptionalTrimmedValue(value) {
+  if (value === undefined || value === null) {
+    return null;
+  }
+  const trimmed = String(value).trim();
+  return trimmed === '' ? null : trimmed;
+}
 
 function parseArgs(rawArgs) {
   const values = {};


### PR DESCRIPTION
## Summary

Fixes the Foundry publication path in the release workflow by replacing the broken `@ghost-fvtt/foundry-publish` invocation with Foundry's official Package Release API.

## Root Cause

The previous workflow invoked `npx @ghost-fvtt/foundry-publish` under npm 11, which resolved to a CLI version requiring different inputs than the workflow provided. It could print an error such as `Missing option packageID` while still exiting successfully, so the release job appeared green without publishing to Foundry.

## Changes

- Adds `foundry_only` mode so an existing GitHub release can be submitted to Foundry without mutating GitHub tags or release assets.
- Builds explicit normal and dry-run Foundry API payloads from the release manifest.
- Uses the official Foundry endpoint `https://foundryvtt.com/_api/packages/release_version/` with the raw `Authorization: ${FVTT_TOKEN}` header documented by Foundry.
- Validates the Foundry payload through the API dry-run before a real publish.
- Polls the public Foundry package page after a real publish and fails if the expected version/verified value does not appear.
- Keeps Discord announcements out of `foundry_only` repair runs.
- Adds focused tests for Foundry payload generation, workflow publish/dry-run split, mutually-exclusive release modes, and defensive payload input validation.

## Review Feedback Addressed

- Replaced the vacuous `announce_only`/`foundry_only` test with assertions against the actual `Validate release inputs` rejection gate.
- Hardened `extractStepBlock` so tests fail when an expected following workflow step is missing.
- Added explicit `moduleJson` object validation before the payload builder reads manifest fields.

## Validation

- `npm ci`
- `npx eslint tools/release/foundry-release-payload.mjs tests/utils/test-foundry-release.mjs`
- `npm run test:foundry-release`
- `npm run test:changelog`
- `npm run lint:json:check`
- `npx prettier --check .github/workflows/create-release.yml tools/release/foundry-release-payload.mjs tests/utils/test-foundry-release.mjs package.json`
- `rg "foundry-publish|@ghost-fvtt" .github/workflows tools tests package.json` returned no matches
- `git diff --check`
- Downloaded public `1.1.0` `module.json` and `simulacrum.zip`; standalone and embedded manifests both show version `1.1.0`, minimum `13`, verified `14`, no `maximum`, and pinned `1.1.0` manifest/download URLs.
- Branch workflow dry run: https://github.com/Daxiongmao87/simulacrum-foundry/actions/runs/27881767789 succeeded on `fix/foundry-publish-api` at `3ae8ec9`; Foundry API dry-run returned success and the real publish/page/Discord steps were skipped by `dry_run=true`.
- PR checks are passing on the updated branch: `Lint & Format` and `GitGuardian Security Checks`.