### PR TITLE
ci: announce new issues in Discord

### DIFF
--- a/.github/workflows/announce-new-issue.yml
+++ b/.github/workflows/announce-new-issue.yml
@@ -1,0 +1,77 @@
+# Announce newly opened issues in Discord
+
+name: Announce New Issue
+
+on:
+  issues:
+    types: [opened]
+
+permissions: {}
+
+jobs:
+  announce:
+    name: Send Discord announcement
+    runs-on: ubuntu-latest
+    timeout-minutes: 2
+
+    steps:
+      - name: Build Discord payload
+        env:
+          REPOSITORY: ${{ github.repository }}
+        run: |
+          jq --arg repository "$REPOSITORY" '
+            def normalized:
+              gsub("[[:space:]]+"; " ")
+              | sub("^ "; "")
+              | sub(" $"; "");
+            def summary:
+              (. // "" | normalized) as $body
+              | if ($body | length) == 0 then
+                  "_No description provided._"
+                elif ($body | length) > 700 then
+                  $body[0:697] + "..."
+                else
+                  $body
+                end;
+            {
+              username: "GitHub Issues",
+              allowed_mentions: {parse: []},
+              embeds: [{
+                title: (
+                  .issue.title
+                  | if length > 256 then .[0:253] + "..." else . end
+                ),
+                url: .issue.html_url,
+                description: (.issue.body | summary),
+                color: 5814783,
+                author: {
+                  name: ("Opened by @" + .issue.user.login),
+                  url: .issue.user.html_url,
+                  icon_url: .issue.user.avatar_url
+                },
+                fields: [{
+                  name: "Issue",
+                  value: (
+                    "[Open issue #" + (.issue.number | tostring) + "](" +
+                    .issue.html_url + ")"
+                  ),
+                  inline: false
+                }],
+                footer: {text: $repository}
+              }]
+            }
+          ' "$GITHUB_EVENT_PATH" > discord-payload.json
+
+      - name: Send Discord announcement
+        env:
+          DISCORD_ISSUE_WEBHOOK_URL: ${{ secrets.DISCORD_ISSUE_WEBHOOK_URL }}
+        run: |
+          if [ -z "$DISCORD_ISSUE_WEBHOOK_URL" ]; then
+            echo "::error::DISCORD_ISSUE_WEBHOOK_URL is not configured"
+            exit 1
+          fi
+
+          curl --fail-with-body --silent --show-error \
+            --header 'Content-Type: application/json' \
+            --data-binary @discord-payload.json \
+            "$DISCORD_ISSUE_WEBHOOK_URL"

--- a/spec/001-announce-new-issues-to-discord.md
+++ b/spec/001-announce-new-issues-to-discord.md
@@ -1,0 +1,25 @@
+# Announce New Issues to Discord
+
+Announce each newly opened GitHub issue through the repository's Discord webhook without
+committing or exposing the webhook credential.
+
+## Acceptance Criteria
+
+- [x] A GitHub Actions workflow runs for the `issues` event only when an issue is opened.
+- [x] The Discord announcement includes the issue title, a concise description summary, and a
+      link to the issue.
+- [x] Empty, multiline, and long descriptions produce a valid bounded Discord payload, and the
+      announcement cannot trigger Discord mentions.
+- [x] The workflow uses least-privilege permissions and reads the webhook URL from the
+      `DISCORD_ISSUE_WEBHOOK_URL` Actions secret.
+
+## Verification
+
+- [x] Prettier accepts the workflow and specification files.
+- [x] A representative issue event produces a payload with the expected title, summary, and URL.
+- [x] Empty and long issue descriptions produce the fallback and truncated summaries without
+      exceeding the configured summary limit.
+- [x] The `DISCORD_ISSUE_WEBHOOK_URL` repository secret is configured, and only its name is
+      observable through repository metadata.
+- [x] The configured Discord webhook endpoint accepts authenticated requests without posting a
+      test announcement.


### PR DESCRIPTION
## Summary

- announce newly opened GitHub issues through Discord
- include a bounded description summary, linked title, issue number, repository, and author
- read the webhook exclusively from the `DISCORD_ISSUE_WEBHOOK_URL` repository secret
- disable Discord mentions and grant the workflow no GitHub token permissions

Related issue: none.

## Empirical Verification (UTRs)

```text
$ npx prettier --check .github/workflows/announce-new-issue.yml spec/001-announce-new-issues-to-discord.md
Prettier: all files formatted

$ go run github.com/rhysd/actionlint/cmd/actionlint@v1.7.12 .github/workflows/announce-new-issue.yml
[exit 0; no diagnostics]

Exact workflow payload step, exercised with representative, empty, and oversized issue events:
PASS representative title: Discord announcement test
PASS representative summary: First line Second line with @everyone
PASS representative URL: https://github.com/daxiongmao87/simulacrum-foundry/issues/42
PASS allowed_mentions: {"parse":[]}
PASS empty summary: _No description provided._
PASS long summary length: 700
PASS long title length: 256

Repository-secret metadata lookup for DISCORD_ISSUE_WEBHOOK_URL:
1 matching secret name

Authenticated webhook metadata request, without posting a message:
HTTP 200

Credential scan of the proposed workflow and specification:
No matches for the Discord webhook URL, webhook ID, or token prefix.
```